### PR TITLE
Add Caddy

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -19,6 +19,13 @@ module.exports = {
     supportsOcspStapling: false,
     usesOpenssl: false,
   },
+  caddy: {
+    highlighter: 'nginx', // TODO: find better
+    latestVersion: '1.0.0',
+    name: 'Caddy',
+    supportsOcspStapling: false, // actually true; can't be disabled in Caddy
+    usesOpenssl: false,
+  },
   haproxy: {
     highlighter: 'nginx',  // TODO: find better
     latestVersion: '1.9.7',

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -1,0 +1,8 @@
+# generated with: {{{output.link}}}
+# replace example.com with your domain name
+example.com
+
+{{#if form.hsts}}
+# HSTS ({{output.hstsMaxAge}} seconds)
+header / Strict-Transport-Security "max-age={{output.hstsMaxAge}};"
+{{/if}}


### PR DESCRIPTION
I think the only thing missing is I'm not sure what to do when Intermediate or Old are selected. Caddy defaults to TLS 1.3 which (in Go at least) doesn't allow customizing cipher suites. Mozilla's current recommendation for Modern says only TLSv1.2, but I'm assuming that just needs to be updated.

In any case, here is how to get a rough equivalent of Modern in Caddy. It's at least a start!