### PR TITLE
Traefik Configuration Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This starts a local webserver that will automatically reload your changes.
 
 There are two places that need to be updated in order to add support for a new piece of software:
 
-`js/configs.js`, which sets the supported features for your software, and
-`templates/partials/your-software.hbs`, a Handlebars.js template that mirrors your software's configuration
+`src/js/configs.js`, which sets the supported features for your software, and
+`src/templates/partials/your-software.hbs`, a Handlebars.js template that mirrors your software's configuration
 
 ## Building
 

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -73,4 +73,12 @@ module.exports = {
     supportsHsts: false,
     supportsOcspStapling: false,
   },
+  traefik: {
+    highlighter: 'toml',
+    latestVersion: '1.7.11',
+    name: 'Traefik',
+    supportsHsts: true,
+    // https://github.com/containous/traefik/issues/212
+    supportsOcspStapling: false
+  }
 };

--- a/src/js/helpers/concat.js
+++ b/src/js/helpers/concat.js
@@ -1,0 +1,5 @@
+export default (...args) => {
+  return args
+  	.slice(0, -1)
+    .join('');
+}

--- a/src/js/helpers/toregex.js
+++ b/src/js/helpers/toregex.js
@@ -1,0 +1,3 @@
+export default (str) => {
+  return new RegExp(str);
+};

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -1,13 +1,9 @@
 # generated with: {{{output.link}}}
 [entryPoints]
 [entryPoints.http.tls]
-{{#if (includes "modern" form.config)}}
-minVersion = "VersionTLS12"
-{{else if (includes "intermedia" form.config)}}
-minVersion = "VersionTLS10"
-{{else}}
-minVersion = "VersionSSL30"
-{{/if}}
+
+{{! See https://regexr.com/4f3e4 for an explanation of the regex. }}
+minVersion = "{{replace (concat (last output.protocols) "0") (toregex "([A-Z]{3})v(\d)\.?(\d)0?") "Version$1$2$3" }}"
 
 cipherSuites = [
 	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -1,0 +1,36 @@
+# generated with: {{{output.link}}}
+[entryPoints]
+[entryPoints.http.tls]
+{{#if (includes "modern" form.config)}}
+minVersion = "VersionTLS12"
+{{else if (includes "intermedia" form.config)}}
+minVersion = "VersionTLS10"
+{{else}}
+minVersion = "VersionSSL30"
+{{/if}}
+
+cipherSuites = [
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_RSA_WITH_AES_256_GCM_SHA384"
+]
+
+{{#if form.hsts}}
+# Traefik configuration for HSTS is on a per-host basis,
+# so the configuration goes inside the Provider
+
+# If you are using the File Provider:
+[file]
+[frontends]
+[frontends.application]
+[frontends.application.headers]
+SSLRedirect = true
+SSLTemporaryRedirect = true
+STSSeconds = {{output.hstsMaxAge}};
+
+# Docker Provider, apply the following label:
+# "traefik.frontend.headers.STSSeconds" = "{{output.hstsMaxAge}}"
+
+# Kubernetes Provider, apply the following annotation on the Ingress:
+# ingress.kubernetes.io/hsts-max-age: "{{output.hstsMaxAge}}"
+
+{{/if}}


### PR DESCRIPTION
I've added basic support for TLS Versions, and HSTS.

Need suggestions on how to approach the Cipher Suite list. Traefik uses https://godoc.org/crypto/tls#pkg-constants, which is not used by any other configuration yet.