### PR TITLE
official branding "moz://a" is lowercase

### DIFF
--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -19,7 +19,7 @@
 <body>
   <div class="container mt-4">
     <div class="h2 pb-2">
-      <span class="bg-black text-white px-3">Moz://a</span>
+      <span class="bg-black text-white px-3">moz://a</span>
       <span class="d-none d-md-inline-block"><%= htmlWebpackPlugin.options.constants.header %></span>
       <span class="d-inline-block d-md-none"><%= htmlWebpackPlugin.options.constants.mobileHeader %></span>
     </div>


### PR DESCRIPTION
Changing "M" into "m"