### PR TITLE
fix postfix template - ciphers vs ciphersuites

### DIFF
--- a/src/templates/partials/postfix.hbs
+++ b/src/templates/partials/postfix.hbs
@@ -17,7 +17,7 @@ smtpd_tls_mandatory_ciphers = medium
 smtpd_tls_dh1024_param_file = /path/to/dhparam.pem
 {{/if}}
 
-{{#if output.cipherSuites.length}}
+{{#if output.ciphers.length}}
 tls_medium_cipherlist = {{{join output.ciphers ":"}}}
 {{/if}}
 tls_preempt_cipherlist = {{#if output.serverPreferredOrder}}yes{{else}}no{{/if}}


### PR DESCRIPTION
I haven't tested this, but I think both should say ciphers. It currently generates "tls_medium_cipherlist=" (empty) which postfix doesn't accept.

Also, I don't see the postfix source calling `SSL*_set_ciphersuites`, so I guess they don't support specifying 1.3 ciphersuites (only ciphers of TLS1.2 and below.)