### PR TITLE
Support for Traefik v2

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -140,7 +140,7 @@ module.exports = {
   traefik: {
     cipherFormat: 'go',
     highlighter: 'ini',
-    latestVersion: '1.7.12',
+    latestVersion: '2.1.1',
     name: 'Traefik',
     supportsHsts: true,
     supportsOcspStapling: false,  // https://github.com/containous/traefik/issues/212

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -5,6 +5,9 @@
   [http.routers.router-secure]
     rule = "Host(`foo.com`)"
     service = "service-id"
+    {{#if form.hsts}}
+    middlewares = ["hsts-header"]
+    {{/if}}
 
     [http.routers.router-secure.tls]
       options = "{{form.config}}"
@@ -14,14 +17,14 @@
     rule = "Host(`foo.com`)"
     service = "service-id"
     {{#if form.hsts}}
-    middlewares = ["redirect"]
+    middlewares = ["redirect-to-https", "hsts-header"]
     {{/if}}
 
 [http.middlewares]
-  [http.middlewares.redirect.redirectScheme]
+  [http.middlewares.redirect-to-https.redirectScheme]
     scheme = "https"
-  [http.middlewares.redirect.headers]
-    [http.middlewares.redirect.headers.customResponseHeaders]
+  [http.middlewares.hsts-header.headers]
+    [http.middlewares.hsts-header.headers.customResponseHeaders]
       Strict-Transport-Security = "max-age={{output.hstsMaxAge}}"
 {{/if}}
 

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -1,73 +1,49 @@
 # generated {{output.date}}, {{{output.link}}}
 {{#if (minver "2.0.0" form.serverVersion)}}
-## static configuration
-# traefik.toml
-
-[entryPoints.web]
-  address = ":80"
-
-[entryPoints.web-secure]
-  address = ":443"
-
-##---------------------##
-
-## dynamic configuration
-# dynamic-conf.toml
-
+{{! traefik 2.0 has a very different configuration style }}
 [http.routers]
+  [http.routers.router-secure]
+    rule = "Host(`foo.com`)"
+    service = "service-id"
+
+    [http.routers.router-secure.tls]
+      options = "{{form.config}}"
+{{#if form.hsts}}
+
   [http.routers.router-insecure]
     rule = "Host(`foo.com`)"
-    service = "my-service"
-    entrypoints = ["web"]
+    service = "service-id"
     {{#if form.hsts}}
     middlewares = ["redirect"]
     {{/if}}
 
-[http.routers.router-secure]
-    rule = "Host(`foo.com`)"
-    service = "my-service"
-    entrypoints = ["web-secure"]
-    [http.routers.router-secure.tls]
-      options = "myTLSOptions"
-
-[http.services]
-  [[http.services.my-service.loadBalancer.servers]]
-    url = "http://my-backend:80"
-
-{{#if form.hsts}}
 [http.middlewares]
   [http.middlewares.redirect.redirectScheme]
     scheme = "https"
+  [http.middlewares.redirect.headers]
+    [http.middlewares.redirect.headers.customResponseHeaders]
+      Strict-Transport-Security = "max-age={{output.hstsMaxAge}}"
 {{/if}}
 
+# due to Go limitations, it is highly recommended that you use an ECDSA
+# certificate, or you may experience compatibility issues
 [[tls.certificates]]
-  certFile = /path/to/signed_cert_plus_intermediates"
+  certFile = "/path/to/signed_cert_plus_intermediates"
   keyFile = "/path/to/private_key"
 
 [tls.options]
-  [tls.options.default]
-    {{#if (eq output.protocols.[0] "TLSv1")}}
-    minVersion = "VersionTLS10"
-    {{else}}
+  [tls.options.{{form.config}}]
     minVersion = "{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}"
-    {{/if}}
-
-  [tls.options.myTLSOptions]
-      {{#if (eq output.protocols.[0] "TLSv1")}}
-      minVersion = "VersionTLS10"
-      {{else}}
-      minVersion = "{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}"
+    {{#if output.ciphers.length}}
+    cipherSuites = [
+    {{#each output.ciphers}}
+      "{{this}}"{{#unless @last}},{{/unless}}
+    {{/each}}
+    ]
       {{/if}}
-      cipherSuites = [
-      {{#each output.ciphers}}
-        "{{this}}"{{#unless @last}},{{/unless}}
-      {{/each}}
-        ]
-
-
 {{else}}
+{{! traefik 1.x configuration style }}
 defaultEntryPoints = ["http", "https"]
-
 
 [entryPoints]
 {{#if form.hsts}}

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -1,5 +1,73 @@
 # generated {{output.date}}, {{{output.link}}}
+{{#if (minver "2.0.0" form.serverVersion)}}
+## static configuration
+# traefik.toml
+
+[entryPoints.web]
+  address = ":80"
+
+[entryPoints.web-secure]
+  address = ":443"
+
+##---------------------##
+
+## dynamic configuration
+# dynamic-conf.toml
+
+[http.routers]
+  [http.routers.router-insecure]
+    rule = "Host(`foo.com`)"
+    service = "my-service"
+    entrypoints = ["web"]
+    {{#if form.hsts}}
+    middlewares = ["redirect"]
+    {{/if}}
+
+[http.routers.router-secure]
+    rule = "Host(`foo.com`)"
+    service = "my-service"
+    entrypoints = ["web-secure"]
+    [http.routers.router-secure.tls]
+      options = "myTLSOptions"
+
+[http.services]
+  [[http.services.my-service.loadBalancer.servers]]
+    url = "http://my-backend:80"
+
+{{#if form.hsts}}
+[http.middlewares]
+  [http.middlewares.redirect.redirectScheme]
+    scheme = "https"
+{{/if}}
+
+[[tls.certificates]]
+  certFile = /path/to/signed_cert_plus_intermediates"
+  keyFile = "/path/to/private_key"
+
+[tls.options]
+  [tls.options.default]
+    {{#if (eq output.protocols.[0] "TLSv1")}}
+    minVersion = "VersionTLS10"
+    {{else}}
+    minVersion = "{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}"
+    {{/if}}
+
+  [tls.options.myTLSOptions]
+      {{#if (eq output.protocols.[0] "TLSv1")}}
+      minVersion = "VersionTLS10"
+      {{else}}
+      minVersion = "{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}"
+      {{/if}}
+      cipherSuites = [
+      {{#each output.ciphers}}
+        "{{this}}"{{#unless @last}},{{/unless}}
+      {{/each}}
+        ]
+
+
+{{else}}
 defaultEntryPoints = ["http", "https"]
+
 
 [entryPoints]
 {{#if form.hsts}}
@@ -30,3 +98,4 @@ defaultEntryPoints = ["http", "https"]
       [[entryPoints.https.tls.certificates]]
       certFile = "/path/to/signed_cert_plus_intermediates"
       keyFile = "/path/to/private_key"
+{{/if}}


### PR DESCRIPTION
These commits add support for the new Traefik v2 configuration format. Starting
with Traefik 2.0, there are now two parts of a Traefik configuration, static
and dynamic configuration. This means the configuration format changed
considerably from a relatively simple format to something more complex.

In `config.js`, updated the latest version of Traefik. In `traefik.hbs`, added
the complete template for the new configuration format, as found in the Traefik
documentation. Especially relevant are the following documentation sections:

- [ TLS Configuration Is Now Dynamic, per Router ]
  https://docs.traefik.io/migration/v1-to-v2/#tls-configuration-is-now-dynamic-per-router

- [ HTTP to HTTPS Redirection Is Now Configured on Routers ]
  https://docs.traefik.io/migration/v1-to-v2/#http-to-https-redirection-is-now-configured-on-routers

Fixes #66