### PR TITLE
Update Intermediate security policy for AWS ALB

### DIFF
--- a/src/templates/partials/awsalb.hbs
+++ b/src/templates/partials/awsalb.hbs
@@ -41,7 +41,7 @@ Resources:
       LoadBalancerArn: !Ref ExampleALB
       Port: 443
       Protocol: HTTPS
-      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}ELBSecurityPolicy-TLS-1-2-2017-01{{/if}}
+      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}ELBSecurityPolicy-FS-1-2-Res-2019-08{{/if}}
 {{#if form.hsts}}
 
   # {{form.serverName}} doesn't support HSTS, but it can redirect to HTTPS


### PR DESCRIPTION
Updates the Intermediate configuration for Amazon Web Services’s Application Load Balancer to `ELBSecurityPolicy-FS-1-2-Res-2019-08` [which was added on October 8, 2019](https://aws.amazon.com/about-aws/whats-new/2019/10/application-load-balancer-and-network-load-balancer-add-new-security-policies-for-forward-secrecy-with-more-strigent-protocols-and-ciphers/).

This policy is the same as the previous `ELBSecurityPolicy-TLS-1-2-2017-01` but removes support for AES128-GCM-SHA256, AES128-SHA256, AES256-GCM-SHA384, and AES256-SHA256.

Here’s a table comparing the TLS 1.2 cipher suites of the [Intermediate configuration](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29), the previous `ELBSecurityPolicy-TLS-1-2-2017-01` security policy, and the new `ELBSecurityPolicy-FS-1-2-Res-2019-08` security policy:

| Intermediate                  | TLS 1.2                       | FS 1.2 Res                    |
|-------------------------------|-------------------------------|-------------------------------|
| ECDHE-ECDSA-AES128-GCM-SHA256 | ECDHE-ECDSA-AES128-GCM-SHA256 | ECDHE-ECDSA-AES128-GCM-SHA256 |
| ECDHE-RSA-AES128-GCM-SHA256   | ECDHE-RSA-AES128-GCM-SHA256   | ECDHE-RSA-AES128-GCM-SHA256   |
| ECDHE-ECDSA-AES256-GCM-SHA384 | ECDHE-ECDSA-AES128-SHA256     | ECDHE-ECDSA-AES128-SHA256     |
| ECDHE-RSA-AES256-GCM-SHA384   | ECDHE-RSA-AES128-SHA256       | ECDHE-RSA-AES128-SHA256       |
| ECDHE-ECDSA-CHACHA20-POLY1305 | ECDHE-ECDSA-AES256-GCM-SHA384 | ECDHE-ECDSA-AES256-GCM-SHA384 |
| ECDHE-RSA-CHACHA20-POLY1305   | ECDHE-RSA-AES256-GCM-SHA384   | ECDHE-RSA-AES256-GCM-SHA384   |
| DHE-RSA-AES128-GCM-SHA256     | ECDHE-ECDSA-AES256-SHA384     | ECDHE-ECDSA-AES256-SHA384     |
| DHE-RSA-AES256-GCM-SHA384     | ECDHE-RSA-AES256-SHA384       | ECDHE-RSA-AES256-SHA384       |
|                               | AES128-GCM-SHA256             |                               |
|                               | AES128-SHA256                 |                               |
|                               | AES256-GCM-SHA384             |                               |
|                               | AES256-SHA256                 |                               |