### PR TITLE
Fix link to AWS ALB security policies

### DIFF
--- a/src/templates/partials/awsalb.hbs
+++ b/src/templates/partials/awsalb.hbs
@@ -1,7 +1,7 @@
 # Please note that Application Load Balancers don't allow you to directly specify protocols
 # and ciphers, so this is the closest existing mapping from the Mozilla {{form.config}}
 # profile onto an existing Amazon SSL Security Policy. For additional information, please see:
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
 
 AWSTemplateFormatVersion: 2010-09-09
 Description: Mozilla ALB configuration generated {{output.date}}, {{{output.link}}}


### PR DESCRIPTION
The previous URL linked to security policies for Classic Load Balancers, however, this file is about Application Load Balancers.