### PR TITLE
Updating PostgreSQL template for version 12

### DIFF
--- a/src/templates/partials/postgresql.hbs
+++ b/src/templates/partials/postgresql.hbs
@@ -11,5 +11,11 @@ ssl_key_file = '/path/to/private_key'
 ssl_dh_params_file = '/path/to/dhparam.pem'
   {{/if}}
 {{/if}}
+{{#if output.ciphers.length}}
 
 ssl_ciphers = '{{{join output.ciphers ":"}}}'
+{{/if}}
+{{#if (minver "12.0.0" form.serverVersion)}}
+
+ssl_min_protocol_version = '{{output.protocols.[0]}}'
+{{/if}}


### PR DESCRIPTION
PostgreSQL version 12 added a new ssl_min_protocol_version configuration
option to control the SSL versions the server uses.

When testing I also discovered that PostgreSQL rejects an empty
ssl_ciphers value, so I've wrapped this in an if to prevent it being
output if ciphers is empty (modern profile).