### PR TITLE
simplify lighttpd config

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -78,7 +78,7 @@ module.exports = {
   },
   lighttpd: {
     highlighter: 'nginx',
-    latestVersion: '1.4.54',
+    latestVersion: '1.4.55',
     name: 'lighttpd',
     tls13: '1.4.53'
   },

--- a/src/templates/partials/lighttpd.hbs
+++ b/src/templates/partials/lighttpd.hbs
@@ -2,16 +2,18 @@
 # {{{output.link}}}
 {{#if form.hsts}}
 $SERVER["socket"] == ":80" {
+{{#if (minver "1.4.50" form.serverVersion)}}
+    url.redirect = ("" => "https://${url.authority}${url.path}${qsa}")
+{{else}}
     $HTTP["host"] =~ ".*" {
         url.redirect = (".*" => "https://%0$0")
     }
+{{/if}}
 }
 
 {{/if}}
 $SERVER["socket"] == ":443" {
-    protocol     = "https://"
     ssl.engine   = "enable"
-    ssl.disable-client-renegotiation = "enable"
 
     # pemfile is cert+privkey, ca-file is the intermediate chain in one file
     ssl.pemfile               = "/path/to/signed_cert_plus_private_key.pem"
@@ -23,11 +25,6 @@ $SERVER["socket"] == ":443" {
     ssl.dh-file               = "/path/to/dhparam.pem"
     {{/if}}
 {{/if}}
-
-    # Environment flag for HTTPS enabled
-    setenv.add-environment = (
-        "HTTPS" => "on"
-    )
 
     # {{form.config}} configuration, tweak to your needs
 {{#if (minver "1.4.48" form.serverVersion)}}


### PR DESCRIPTION
simplify lighttpd config

* latest version is lighttpd 1.4.55  (how does docs/39dd7eed14622039aa44.index.js get updated?)
* lighttpd 1.4.50 and later has simpler (and more efficient) syntax for http to https redirect
* `protocol = "https://"` is not use by lighttpd.conf and gets ignored
* `ssl.disable-client-renegotiation = "enable"` is the default, and always has been for that config option.
* `setenv.add-environment = ( "HTTPS" => "on" )` is unnecessary, as lighttpd already does this for backends when the connection uses https.

Greetings from a lighttpd developer. :)