### PR TITLE
The quotes are important :)

### DIFF
--- a/src/templates/partials/redis.hbs
+++ b/src/templates/partials/redis.hbs
@@ -19,7 +19,7 @@ tls-dh-params-file /path/to/dhparam
 {{/if}}
 
 # {{form.config}} configuration
-tls-protocols {{#each output.protocols}}{{this}}{{#unless @last}} {{/unless}}{{/each}}
+tls-protocols "{{#each output.protocols}}{{this}}{{#unless @last}} {{/unless}}{{/each}}"
 {{#if output.ciphers.length}}
 tls-ciphers {{{join output.ciphers ":"}}}
 {{/if}}


### PR DESCRIPTION
The quotation marks around TLS protocols prevent Redis from interpreting each individual protocol as a separate argument and groups all of them together.