### PR TITLE
Use noSupportedVersion since dovecot doesn't support TLSv1.3 for now

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -50,7 +50,7 @@ module.exports = {
     showSupports: false,
     supportsHsts: false,
     supportsOcspStapling: false,
-    tls13: '2.0.0',
+    tls13: noSupportedVersion,
   },
   exim: {
     highlighter: 'nginx',


### PR DESCRIPTION
Since the fix to allow Dovecot to recognize the option to make use of TLSv1.3 it has not been merged for now, I think we should disable the "modern" configuration since it leads to a non-working config file.