### PR TITLE
Nginx: Wrap "return 301" inside a `location` block

### DIFF
--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -5,7 +5,9 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    return 301 https://$host$request_uri;
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 {{/if}}


### PR DESCRIPTION
This fixes #95.

I have tested the config in an nginx/1.14.2 on Debian. 
I have not checked if the code still builds, but I don't see, how modifying a template this way, would influence this.

Thanks to @runapp for the suggestion.

Greetings Nmxosm