### PR TITLE
Add Squid support

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -159,7 +159,7 @@ module.exports = {
   },
   squid: {
     highlighter: 'nginx',  // TODO: find better
-    latestVersion: '4.14',
+    latestVersion: '5.6',
     name: 'Squid',
     showSupports: false,
     supportsHsts: false,

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -157,6 +157,15 @@ module.exports = {
     tls13: '6.0',
     usesOpenssl: true,
   },
+  squid: {
+    highlighter: 'nginx',  // TODO: find better
+    latestVersion: '4.14',
+    name: 'Squid',
+    showSupports: false,
+    supportsHsts: false,
+    supportsOcspStapling: false,
+    tls13: '3.5',
+  },
   tomcat: {
     highlighter: 'xml',
     latestVersion: '9.0.30',

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -164,7 +164,7 @@ module.exports = {
     showSupports: false,
     supportsHsts: false,
     supportsOcspStapling: false,
-    tls13: '3.5',
+    tls13: '4',
   },
   tomcat: {
     highlighter: 'xml',

--- a/src/templates/partials/squid.hbs
+++ b/src/templates/partials/squid.hbs
@@ -1,0 +1,34 @@
+# {{output.header}}
+# {{{output.link}}}
+
+# The following example shows Squid configured as a cache proxy with SSL bump enabled
+
+http_port 3128 ssl-bump \
+  {{#if (minver "4" form.serverVersion)}}tls-{{/if}}cert=/path/to/ca_signing_cert \
+  {{#if (minver "4" form.serverVersion)}}tls-{{/if}}key=/path/to/ca_signing_private_key \
+{{#if output.ciphers.length}}
+  cipher={{{join output.ciphers ":"}}} \
+{{/if}}
+{{#if output.usesDhe}}
+  tls-dh=/path/to/dhparam \  # {{output.dhCommand}} > /path/to/dhparam
+{{/if}}
+  options={{#if (minver "4" form.serverVersion)}}NO_SSLv3{{else}}NO_SSLv2,NO_SSLv3{{/if}}{{#unless (includes "TLSv1" output.protocols)}},NO_TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}},NO_TLSv1_1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}},NO_TLSv1_2{{/unless}},NO_TICKET
+
+sslcrtd_program /usr/lib/squid/{{#if (minver "4" form.serverVersion)}}security_file_certgen{{else}}ssl_crtd{{/if}} -s /var/cache/squid/ssl_db -M 4MB
+acl step1 at_step SslBump1
+ssl_bump peek step1
+ssl_bump bump all
+
+
+# The following example shows Squid configured as a reverse Proxy / Accelerator
+
+https_port 443 accel defaultsite=example.net \
+  {{#if (minver "4" form.serverVersion)}}tls-{{/if}}cert=/path/to/signed_cert_plus_intermediates \
+  {{#if (minver "4" form.serverVersion)}}tls-{{/if}}key=/path/to/private_key \
+{{#if output.ciphers.length}}
+  cipher={{{join output.ciphers ":"}}} \
+{{/if}}
+{{#if output.usesDhe}}
+  tls-dh=/path/to/dhparam \  # {{output.dhCommand}} > /path/to/dhparam
+{{/if}}
+  options={{#if (minver "4" form.serverVersion)}}NO_SSLv3{{else}}NO_SSLv2,NO_SSLv3{{/if}}{{#unless (includes "TLSv1" output.protocols)}},NO_TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}},NO_TLSv1_1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}},NO_TLSv1_2{{/unless}},NO_TICKET


### PR DESCRIPTION
The configuration is done to support Squid >= 3.5 ([The oldest version packaged in common Linux distributions](https://pkgs.org/download/squid))

The generated configuration was tested in the following conditions:
- Tested both "Intermediate" and "Modern" configurations
- Only in the "cache proxy with SSL bump" mode
- Only with Squid 4.14 on Fedora 34

I didn't find exactly what is the first Squid version that support TLS 1.3, so I set it to 3.5 in `configs.js`.

Close #112