### PR TITLE
Dovecot: Add TLS 1.3 support and update latest version.

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -45,12 +45,12 @@ module.exports = {
   },
   dovecot: {
     highlighter: 'nginx', // TODO: find better
-    latestVersion: '2.3.9',
+    latestVersion: '2.3.16',
     name: 'Dovecot',
     showSupports: false,
     supportsHsts: false,
     supportsOcspStapling: false,
-    tls13: noSupportedVersion,
+    tls13: '2.3.15',
   },
   exim: {
     highlighter: 'nginx',


### PR DESCRIPTION
Close #156.

https://doc.dovecot.org/settings/core/#core_setting-ssl_min_protocol