### PR TITLE
Fix ciphers not configured for STARTTLS when postfix < 3.1

### DIFF
--- a/src/templates/partials/postfix.hbs
+++ b/src/templates/partials/postfix.hbs
@@ -7,6 +7,7 @@ smtpd_tls_key_file = /path/to/private_key
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3{{#unless (includes "TLSv1" output.protocols)}}, !TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}}, !TLSv1.1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}}, !TLSv1.2{{/unless}}
 smtpd_tls_protocols = !SSLv2, !SSLv3{{#unless (includes "TLSv1" output.protocols)}}, !TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}}, !TLSv1.1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}}, !TLSv1.2{{/unless}}
 {{#if output.ciphers.length}}
+smtpd_tls_ciphers = medium
 smtpd_tls_mandatory_ciphers = medium
 {{/if}}
 {{#if output.usesDhe}}


### PR DESCRIPTION
I tried generated configuration with Postfix 2.10.1, however I noticed the ciphers for `STARTTLS` are not changed. Investigating, default of `smtpd_tls_ciphers` is `medium` on postfix >= 3.1.0, however `export` on postfix < 3.1.0.

I consider that the configuration should have `smtpd_tls_ciphers` line.

* Postfix 3.1.0: https://github.com/vdukhovni/postfix/blob/v3.1.0/postfix/src/global/mail_params.h#L1320
* Postfix 3.0.0: https://github.com/vdukhovni/postfix/blob/v3.0.0/postfix/src/global/mail_params.h#L1319