### PR TITLE
lighttpd 1.4.65 version update

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -88,7 +88,7 @@ module.exports = {
   },
   lighttpd: {
     highlighter: 'nginx',
-    latestVersion: '1.4.63',
+    latestVersion: '1.4.65',
     name: 'lighttpd',
     tls13: '1.4.48'
   },


### PR DESCRIPTION
lighttpd 1.4.65 version update

Please also review some simple but older PRs: https://github.com/mozilla/ssl-config-generator/pull/137 for Apache and https://github.com/mozilla/ssl-config-generator/pull/139 for lighttpd for them to prefer 308 Permanent Redirect to 301 Moved Permanently

Thank you.