### PR TITLE
Add support for local development with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+CODE_OF_CONDUCT.md
+Dockerfile
+LICENSE
+tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY . ./
+
+RUN apk add --no-cache git && \
+    npm install
+
+ENTRYPOINT ["npm", "run", "watch"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ $ npm run watch
 
 This starts a local webserver that will automatically reload your changes.
 
+Alternatively, you can use [Docker](https://www.docker.com/) to run the local webserver to avoid
+cluttering your local environment with npm dependencies. You first need to build the docker:
+
+```bash
+docker build -t moz-ssl-config-gen:latest .
+```
+
+You can then run the webserver:
+
+```bash
+docker run -p 3001:3001 -p 5500:5500 moz-ssl-config-gen:latest
+```
+
 ## Adding new software
 
 There are two places that need to be updated in order to add support for a new piece of software:


### PR DESCRIPTION
All the node dependencies can clutter your local machine, and you may need different versions of node installed.

The Dockerfile was mainly inspired by the official documentation for NodeJS. https://nodejs.org/en/docs/guides/nodejs-docker-webapp/

Please be aware that there are several dependencies which are listed with `npm audit`. I'm not sure how much bandwidth you have for this project, but I'd suggest adding [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates) to the project.