### PR TITLE
Add regular scans with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
There's already a PR from dependabot for upgrading Node Sass to a more recent version in #167. This PR enables a weekly scan. If you run `npm audit`, there are different warnings for the libraries. I didn't explore the severeness of them. https://docs.npmjs.com/cli/v8/commands/npm-audit 