### PR TITLE
Update AWS ALB security policies for 2023.3.22

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -14,11 +14,11 @@ module.exports = {
   awsalb: {
     hasVersions: false,
     highlighter: 'yaml',
-    latestVersion: '2019.8.1',
+    latestVersion: '2023.3.22',
     name: 'AWS ALB',
     showSupports: false,
     supportsOcspStapling: false,
-    tls13: noSupportedVersion,
+    tls13: '2023.3.22',
     usesOpenssl: false,
   },
   // supported ciphers generated with:

--- a/src/templates/partials/awsalb.hbs
+++ b/src/templates/partials/awsalb.hbs
@@ -40,7 +40,7 @@ Resources:
       LoadBalancerArn: !Ref ExampleALB
       Port: 443
       Protocol: HTTPS
-      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}ELBSecurityPolicy-FS-1-2-Res-2019-08{{/if}}
+      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}{{#if (includes "TLSv1.2" output.protocols)}}ELBSecurityPolicy-TLS13-1-2-2021-06{{else}}ELBSecurityPolicy-TLS13-1-3-2021-06{{/if}}{{/if}}
 {{#if form.hsts}}
 
   # {{form.serverName}} doesn't support HSTS, but it can redirect to HTTPS

--- a/src/templates/partials/awsalb.hbs
+++ b/src/templates/partials/awsalb.hbs
@@ -40,7 +40,7 @@ Resources:
       LoadBalancerArn: !Ref ExampleALB
       Port: 443
       Protocol: HTTPS
-      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}{{#if (includes "TLSv1.2" output.protocols)}}ELBSecurityPolicy-TLS13-1-2-2021-06{{else}}ELBSecurityPolicy-TLS13-1-3-2021-06{{/if}}{{/if}}
+      SslPolicy: {{#if (includes "TLSv1" output.protocols)}}ELBSecurityPolicy-TLS-1-0-2015-04{{else}}{{#if (includes "TLSv1.2" output.protocols)}}ELBSecurityPolicy-TLS13-1-2-Res-2021-06{{else}}ELBSecurityPolicy-TLS13-1-3-2021-06{{/if}}{{/if}}
 {{#if form.hsts}}
 
   # {{form.serverName}} doesn't support HSTS, but it can redirect to HTTPS


### PR DESCRIPTION
From this accouncement:
https://aws.amazon.com/about-aws/whats-new/2023/03/application-load-balancer-tls-1-3/ TLSv1.3 support is now generally available in AWS ALB. They have added a new set of security policies that enable TLSv1.3. I have selected the following policies which are the closest fit to the Mozilla server side TLS recommendations:

**Old:**
Remains `TLS-1-0-2015-04`. This policy doesn't support TLSv1.3, but it is the only policy available which supports DES-CBC3-SHA.

**Intermediate:**
Switched from `FS-1-2-Res-2019-08` to `TLS13-1-2-2021-06`. These two policies support the same set of TLSv1.2 ciphers, but the newer one also adds TLSv1.3 support.

**Modern:**
Can be supported now, using `TLS13-1-3-2021-06`.