### PR TITLE
Fix incorrect href in 5.0 JSON guideline

### DIFF
--- a/src/static/guidelines/5.0.json
+++ b/src/static/guidelines/5.0.json
@@ -1,5 +1,5 @@
 {
-    "href": "https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json",
+    "href": "https://statics.tls.security.mozilla.org/server-side-tls-conf-5.0.json",
     "configurations": {
         "modern": {
             "openssl_ciphers": [],


### PR DESCRIPTION
I incorrectly fixed this in the `/docs` directory in #200 . It should have been fixed here in `/src`