### PR TITLE
Add new http2 directive since 1.25.1

### DIFF
--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -13,8 +13,15 @@ server {
 {{/if}}
 server {
 {{#if (minver "1.9.5" form.serverVersion)}}
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    {{#if (minver "1.25.1" form.serverVersion)}}
+        listen 443 ssl;
+        listen [::]:443 ssl;
+
+        http2 on;
+    {{else}}
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+    {{/if}}
 {{else}}
     listen 443 ssl;
     listen [::]:443 ssl;


### PR DESCRIPTION
HTTP2 directive: https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2

Related issue: https://github.com/mozilla/ssl-config-generator/issues/210

*N.B.: I'm **not** a dev*