### PR TITLE
Update minimist to 1.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "handlebars": "^4.7.8",
         "highlight.js": "^10.7.3",
         "jquery": "^3.7.1",
+        "minimist": "^1.2.8",
         "popper.js": "^1.16.1",
         "semver": "^6.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "handlebars": "^4.7.8",
     "highlight.js": "^10.7.3",
     "jquery": "^3.7.1",
+    "minimist": "^1.2.8",
     "popper.js": "^1.16.1",
     "semver": "^6.3.1"
   },


### PR DESCRIPTION
The current version of handlebars (4.7.8) depends on minimist but specifies the vulnerable version (1.2.5).

Until handlebars 5 comes out, we need to set a minimist version manually. After it's out we can remove the dependency on minimist

https://github.com/handlebars-lang/handlebars.js/issues/1851