### PR TITLE
Update Oracle serverPreferredOrder

### DIFF
--- a/src/templates/partials/oraclehttp.hbs
+++ b/src/templates/partials/oraclehttp.hbs
@@ -20,4 +20,4 @@
 # {{form.config}} configuration
 SSLProtocol             All {{#unless (includes "TLSv1" output.protocols)}}-TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
-SSLHonorCipherOrder     on
+SSLHonorCipherOrder     {{#if output.serverPreferredOrder}}on{{else}}off{{/if}}

--- a/src/templates/partials/oraclehttp.hbs
+++ b/src/templates/partials/oraclehttp.hbs
@@ -20,4 +20,6 @@
 # {{form.config}} configuration
 SSLProtocol             All {{#unless (includes "TLSv1" output.protocols)}}-TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
+{{#if (minver "12.2.1" form.serverVersion)}}
 SSLHonorCipherOrder     {{#if output.serverPreferredOrder}}on{{else}}off{{/if}}
+{{/if}}


### PR DESCRIPTION
Enables setting `SSLHonorCipherOrder` per config output to adhere to recommendations.

(This hasn't been updated in oraclehttp since v4 and doesn't match current v5.x specs.)

Adds version test for OHS 12.2.1 according to [KB 1485047.1](https://support.oracle.com/knowledge/Middleware/1485047_1.html)