### PR TITLE
Update Apache stapling version

### DIFF
--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -59,7 +59,7 @@ SSLSessionTickets       off
   {{/if}}
 {{/if}}
 {{#if form.ocsp}}
-  {{#if (minver "2.4.14" form.serverVersion)}}
+  {{#if (minver "2.4.13" form.serverVersion)}}
 
 SSLUseStapling On
 SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"


### PR DESCRIPTION
I haven't found any reference why restrict to 2.4.14+ — bugs were in 2.4.10 and 2.4.11 implementations, good performance is reported since 2.4.13; this updates it accordingly.