### PR TITLE
Fix Jetty `intermediate`/`old` configs for TLSv1.3-only clients

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -88,7 +88,7 @@ module.exports = {
   jetty: {
     cipherFormat: 'iana',
     highlighter: 'xml',
-    latestVersion: '9.4.28',
+    latestVersion: '12.0.5',
     name: 'Jetty',
     supportsHsts: false,
     supportsOcspStapling: false,

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -88,7 +88,7 @@ module.exports = {
   jetty: {
     cipherFormat: 'iana',
     highlighter: 'xml',
-    latestVersion: '12.0.5',
+    latestVersion: '12.0.12',
     name: 'Jetty',
     supportsHsts: false,
     supportsOcspStapling: false,

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -6,7 +6,7 @@
     <Property name="jetty.sslContext.keyStorePath" default="/path/to/key_store" />
   </Set>
 
-  <!-- TLS 1.3 requires Java 11 or higher -->
+  {{#if (includes "TLSv1.3" output.protocols)}}<!-- TLSv1.3 requires Java 11 or higher -->{{/if}}
   <Set name="IncludeProtocols">
     <Array type="String">
       {{#each output.protocols}}
@@ -18,6 +18,11 @@
 {{#if output.ciphers.length}}
   <Set name="IncludeCipherSuites">
     <Array type="String">
+  {{#if (includes "TLSv1.3" output.protocols)}}
+    {{#each output.cipherSuites}}
+      <Item>{{this}}</Item>
+    {{/each}}
+  {{/if}}
   {{#each output.ciphers}}
       <Item>{{this}}</Item>
   {{/each}}


### PR DESCRIPTION
Fixes #154

With any `output.ciphers` present, for TLSv1.3 to work also the `output.cipherSuites` have to be provided for TLSv1.3 handshakes not to fail (i.e. when `IncludeCipherSuites` defined, also the TLSv1.3 compatible suites as defined in RFC 8446 have to be explicitly set, or TLSv1.3-only clients won't be able to connect).

Fixes `intermediate` and `old` configs.

_Support for `*_CHACHA20_POLY1305_*` was added in 11.0.13 [JDK-8140466](https://bugs.openjdk.org/browse/JDK-8140466) but since it was not addressed for TLSv12 suites before, I haven't added anything mentioning the JSSE support for TLSv13 either — if that errors out for someone running older revisions, feel free to open separate issue for that; however we're not comparing such versions in the logic here, so it may only warrant a config comment of sorts…_