### PR TITLE
Join output protocols

### DIFF
--- a/src/templates/partials/mysql.hbs
+++ b/src/templates/partials/mysql.hbs
@@ -7,4 +7,4 @@ ssl-key = /path/to/private_key
 {{#if output.ciphers.length}}
 ssl-cipher = {{{join output.ciphers ":"}}}
 {{/if}}
-tls_version = {{#each output.protocols}}{{this}}{{#unless @last}},{{/unless}}{{/each}}
+tls_version = {{join output.protocols ","}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -42,7 +42,7 @@ server {
 
 {{/if}}
     # {{form.config}} configuration
-    ssl_protocols{{#each output.protocols}} {{this}}{{/each}};
+    ssl_protocols {{join output.protocols " "}};
 {{#if output.ciphers.length}}
     ssl_ciphers {{{join output.ciphers ":"}}};
 {{/if}}

--- a/src/templates/partials/proftpd.hbs
+++ b/src/templates/partials/proftpd.hbs
@@ -19,7 +19,7 @@ TLSDHParamFile                /path/to/dhparam
 {{/if}}
 
 # {{form.config}} configuration
-TLSProtocol                  {{#each output.protocols}} {{this}}{{/each}}
+TLSProtocol                   {{join output.protocols " "}}
 {{#if output.ciphers.length}}
 TLSCipherSuite                {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/redis.hbs
+++ b/src/templates/partials/redis.hbs
@@ -19,7 +19,7 @@ tls-dh-params-file /path/to/dhparam
 {{/if}}
 
 # {{form.config}} configuration
-tls-protocols "{{#each output.protocols}}{{this}}{{#unless @last}} {{/unless}}{{/each}}"
+tls-protocols "{{join output.protocols " "}}"
 {{#if output.ciphers.length}}
 tls-ciphers {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/tomcat.hbs
+++ b/src/templates/partials/tomcat.hbs
@@ -17,7 +17,7 @@
 {{/if}}
         disableSessionTickets="true"
         honorCipherOrder="{{#if output.serverPreferredOrder}}true{{else}}false{{/if}}"
-        protocols="{{#each output.protocols}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}">
+        protocols="{{join output.protocols ", "}}">
 
         <Certificate
             certificateFile="/path/to/signed_certificate"


### PR DESCRIPTION
Replaces variety of `each/unless` historic constructs with more readable `join()` helper that was added later where nothing more complex is necessary (mysql, nginx, proftpd, redis, tomcat) mainly to get rid of fighting the separators and wrestling with negative space tricks. (More complex iterations for XML or quotes were left intact.)

_(Tested, no change to output.)_