### PR TITLE
Fix #openssl-version readonly toggle

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,7 +45,7 @@ const render = async () => {
 
   // enable and disable the appropriate fields
   $('#version').toggleClass('text-disabled', _state.output.hasVersions === false);
-  $('#openssl-version').toggleClass('text-disabled', _state.output.usesOpenssl === false);
+  $('#openssl').toggleClass('text-disabled', _state.output.usesOpenssl === false);
   $('#hsts').prop('disabled', _state.output.supportsHsts === false);
   $('#ocsp').prop('disabled', _state.output.supportsOcspStapling === false);
 


### PR DESCRIPTION
When a server doesn't use OpenSSL, its input should be disabled. This used to work, but got broken in fd14d6f when shortening URLs.

The readonly toggle helps understanding the context at least a bit (a mouseover explainer for disabled inputs would be even better), helping the UI make a little more sense.


https://github.com/mozilla/ssl-config-generator/assets/1784648/853c8e45-2f4e-47e1-94bb-e513cc3860d4