### PR TITLE
Add build & deploy workflow for github-pages environment

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,10 +1,10 @@
 name: deploy-to-production
 
 on:
+  workflow_dispatch: # allow manual runs
   push:
-    branches: ["master"]
-  # Allows workflow run manually from Actions tab:
-  workflow_dispatch:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -12,12 +12,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
-defaults:
-  run:
-    shell: bash
+  group: github-pages
+  cancel-in-progress: false # skip any intermediate builds but let finish
 
 jobs:
   build:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -28,13 +28,13 @@ jobs:
           cache: npm
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Install dependencies
         run: npm ci
       - name: Build with Webpack
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs
 

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,0 +1,54 @@
+name: deploy-to-production
+
+on:
+  push:
+    branches: ["master"]
+  # Allows workflow run manually from Actions tab:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with Webpack
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves #161 

Publishes ssl-config-generator to production from master. No underlying git history and/or keeping a separate branch needed, artifacts are built and published straight to the deployment environment.

Compiles under 10sec, whole npm ci takes about ~30sec, all in all builds and deploys under 1 minute.

![Screen Shot 2024-03-15 at 22 49 40](https://github.com/mozilla/ssl-config-generator/assets/1784648/802f8f69-ff81-4b57-8935-058ffe8ef3a7)

![Screen Shot 2024-03-15 at 22 53 49](https://github.com/mozilla/ssl-config-generator/assets/1784648/e51f35c7-98c9-4e84-a4b5-ffc99d52834d)
