### PR TITLE
Add matrix strategy to test node versions building PRs

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,25 @@
+name: test-build
+
+on:
+  workflow_dispatch: # allow manual runs
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with Webpack
+        run: npm run build


### PR DESCRIPTION
Until preview builds are added here, this at least shows some basic feasibility of package updates and nodejs version compatibility on the webpack build output.

![Screen Shot 2024-10-04 at 23 04 01](https://github.com/user-attachments/assets/14838382-92a1-4e2d-9b13-daa93b96ede2)

`test-build #1` workflow run e.g. [step:5:350](https://github.com/mozilla/ssl-config-generator/actions/runs/11186792442/job/31102543824#step:5:350)
