### PR TITLE
Update JSON v4.0–v5.0 specs canonical location

### DIFF
--- a/src/static/guidelines/4.0.json
+++ b/src/static/guidelines/4.0.json
@@ -1,5 +1,5 @@
 {
-    "href": "https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json",
+    "href": "https://ssl-config.mozilla.org/guidelines/4.0.json",
     "configurations": {
         "modern": {
             "openssl_ciphersuites": "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256",

--- a/src/static/guidelines/5.0.json
+++ b/src/static/guidelines/5.0.json
@@ -1,5 +1,5 @@
 {
-    "href": "https://statics.tls.security.mozilla.org/server-side-tls-conf-5.0.json",
+    "href": "https://ssl-config.mozilla.org/guidelines/5.0.json",
     "configurations": {
         "modern": {
             "openssl_ciphers": [],


### PR DESCRIPTION
These files were originally being uploaded to the infosec S3 bucket that's no longer used for the spec JSONs publishing (the source for that was the former repo, before spinning off the tool here) — so this only matches the newer files that already use the current GH.io–hosted deployment, for them to correctly self-reference their location going forward.

_(This only changes the deployed jsons under the current hostname, to reference their location where they are being loaded from; all the pre-existing jsons kept in the statics bucket for posterity will have their href unchanged, and when loaded from the security statics will still reference themselves correctly there.)_

These came in via 1285bc8 but the hrefs were never updated to match.