### PR TITLE
Allow nginx ≥1.23.2 `ssl_session_tickets`

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -113,12 +113,12 @@ module.exports = {
   nginx: {
     checked: true,
     highlighter: 'nginx',
-    latestVersion: '1.17.7',
+    latestVersion: '1.26.0',
     name: 'nginx',
     tls13: '1.13.0',
   },
   openssl: {
-    latestVersion: '1.1.1k',
+    latestVersion: '1.1.1w',
     tls13: '1.1.1',
   },
   oraclehttp: {

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -30,11 +30,13 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+{{#unless (minver "1.23.2" form.serverVersion)}}
 {{#if (minver "1.0.2l" form.opensslVersion)}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}
 {{/if}}
+{{/unless}}
 
 {{#if output.usesDhe}}
     # {{output.dhCommand}} > /path/to/dhparam


### PR DESCRIPTION
Disabled in https://github.com/mozilla/server-side-tls/pull/80 (as explained in [archive](https://wiki.mozilla.org/Security/Archive/Server_Side_TLS_4.0#TLS_tickets_.28RFC_5077.29) and in detail https://github.com/mozilla/server-side-tls/issues/135), this can now be left out for nginx:

> "TLS session tickets encryption keys are now automatically rotated when using shared memory in the `ssl_session_cache` directive."

— _https://trac.nginx.org/nginx/milestone/nginx-1.23.2 (https://nginx.org/en/CHANGES-1.24)_


Fixes https://github.com/mozilla/server-side-tls/issues/284, https://github.com/mozilla/server-side-tls/issues/282, and tangentially resolves #69
(Also fixes #239 along the way by updating the versions used…)