### PR TITLE
Lower SECLEVEL in `old` config for OpenSSL 3.x compatibility

### DIFF
--- a/src/js/state.js
+++ b/src/js/state.js
@@ -41,6 +41,11 @@ export default async function () {
   } else {
     ciphers = ciphers;
   }
+  if (ciphers.length && ciphers[0] === '@SECLEVEL=0') ciphers.shift();
+  if (configs[server].usesOpenssl !== false && minver('3.0.0', form['openssl'].value)) {
+    // set SECLEVEL=0 via cipher string to support TLSv1-1.1 "old" with OpenSSL 3.x
+    if (protocols.includes('TLSv1.1')) ciphers.unshift('@SECLEVEL=0');
+  }
 
   const state = {
     form: {


### PR DESCRIPTION
Updates to support OpenSSL 3.x

Resolves #188
Tracked in #260

* Set SECLEVEL=0 in cipherstring for `old` output to allow TLSv1–v1.1 for OpenSSL 3.x
* ~Hide DH parameters for servers calling OpenSSL interfaces `SSL_CTX_set_dh_auto()` or `SSL_set_dh_auto()` to use RFC7919.~ (TLS1.2 will keep just ffdhe2048, TLS1.3 will have to limit curves/groups, followup TBD)

- - - - -

TESTING:
https://test-3x--mozsslconf-dev.netlify.app/#openssl=3.3.3&config=old&server=postgresql