### PR TITLE
Update Apache version for appending dhparam to cert file

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -7,7 +7,7 @@ const noSupportedVersion = '10000.10000.10000';
 module.exports = {
   apache: {
     highlighter: 'apache',
-    latestVersion: '2.4.41',
+    latestVersion: '2.4.60',
     name: 'Apache',
     tls13: '2.4.36',
   },

--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -12,7 +12,7 @@
 {{/if}}
 <VirtualHost *:443>
     SSLEngine on
-{{#if (minver "2.4.8" form.serverVersion)}}
+{{#if (minver "2.4.7" form.serverVersion)}}
   {{#if output.usesDhe}}
 
     # {{output.dhCommand}} >> /path/to/signed_cert_and_intermediate_certs_and_dhparams


### PR DESCRIPTION
Fixup according to `mod_ssl` docs:

> "Custom DH parameters and an EC curve name for ephemeral keys, can also be added to end of the first file configured using [`SSLCertificateFile`](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatefile). This is supported in version **2.4.7 or later**."