### PR TITLE
Replace config name with feature check in go/caddy conditions

### DIFF
--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -2,12 +2,6 @@
 # {{{output.link}}}
 {{#unless (minver "2.0.0" form.serverVersion)}}
 # note that Caddy version 1 reached end-of-life > 4 years ago back in 2020
-{{else}}
-{{#if (includes "old" form.config)}}
-# note that Caddy supports only TLSv1.2 and later
-{{else}}
-# note that Caddy automatically configures safe TLS settings
-{{/if}}
 {{/unless}}
 
 # replace example.com with your domain name
@@ -15,10 +9,20 @@ example.com {
 
   tls {
 {{#if output.ciphers.length}}
+  {{#if (includes "TLSv1.2" output.protocols)}}
     # Due to a lack of DHE support, you -must- use an ECDSA cert to support IE 11 on Windows 7
+
+  {{/if}}
+    # Note: Caddy automatically configures safe TLS settings,
+    # so 'ciphers' may safely be commented out to use Caddy defaults.
     ciphers {{{join output.ciphers " "}}}
 {{/if}}
-{{#if (includes "modern" form.config)}}
+{{#if (includes "TLSv1.2" output.protocols)}}
+  {{#if (includes "TLSv1.1" output.protocols)}}
+    # Note: Caddy supports only TLSv1.2 and later
+  {{/if}}
+    #protocols tls1.2 tls1.3
+{{else if (includes "TLSv1.3" output.protocols)}}
     protocols tls1.3
 {{/if}}
   }

--- a/src/templates/partials/go.hbs
+++ b/src/templates/partials/go.hbs
@@ -34,9 +34,11 @@ func main() {
 {{/if}}
 
 {{#if output.ciphers.length}}
-  {{#if (includes "intermediate" form.config)}}
+  {{#unless (includes "TLSv1.1" output.protocols)}}
+  {{#if (includes "TLSv1.2" output.protocols)}}
     // Due to a lack of DHE support, you -must- use an ECDSA cert to support IE 11 on Windows 7
   {{/if}}
+  {{/unless}}
 {{/if}}
     cfg := &tls.Config{
         MinVersion: tls.{{#if (eq output.protocols.[0] "TLSv1")}}VersionTLS10{{else}}{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}{{/if}},


### PR DESCRIPTION
Replace `form.config` in template conditionals
Instead, prefer to check output.protocols in template conditionals.