### PR TITLE
Enable OpenSSL 3.x as the default in UI

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -118,7 +118,7 @@ module.exports = {
     tls13: '1.13.0',
   },
   openssl: {
-    latestVersion: '1.1.1w',
+    latestVersion: '3.4.0',
     tls13: '1.1.1',
   },
   oraclehttp: {


### PR DESCRIPTION
In #256 the support for v3 changes is being added. It can be released without making the 3.x branch the default for everyone, allowing some time to offer it as a preview feature, as "opt-in", before settling on that as the new default for anyone and everyone.

This is a followup, to enable the v3.x as our new default, to stage the rollout in two phases — once we're happy with the #256 changes for the current 1.1.1 configs (e.g. where changing dhparams for the current defaults), as well as any feedback on the new changes (leaving out dhparams in favour of handshake automagic selection, and lowering seclevel for `old` via patching the cipherstring) it brings once switched as the new default.