### PR TITLE
Simplify protocol logic for Apache

### DIFF
--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -38,14 +38,10 @@
 </VirtualHost>
 
 # {{form.config}} configuration
-{{#if (minver "2.3.16" form.serverVersion)}}
-SSLProtocol             all {{#unless (includes "SSLv3" output.protocols)}}-SSLv3{{/unless}}
-                            {{~#unless (includes "TLSv1" output.protocols)}} -TLSv1{{/unless}}
-                            {{~#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
-                            {{~#unless (includes "TLSv1.2" output.protocols)}} -TLSv1.2{{/unless}}
-{{else}}
-SSLProtocol             all -SSLv2 {{#unless (includes "SSLv3" output.protocols)}}-SSLv3 {{/unless}}{{#unless (includes "TLSv1" output.protocols)}}-TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}} -TLSv1.2{{/unless}}
-{{/if}}
+SSLProtocol             all {{#unless (minver "2.3.16" form.serverVersion)}}-SSLv2 {{/unless}}-SSLv3
+                        {{~#unless (includes "TLSv1" output.protocols)}} -TLSv1{{/unless}}
+                        {{~#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
+                        {{~#unless (includes "TLSv1.2" output.protocols)}} -TLSv1.2{{/unless}}
 {{#if output.ciphers.length}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
 {{/if}}


### PR DESCRIPTION
Folding two different `SSLProtocol` blocks into one, without any change to the logic in use or the final output.

## Rationale

The only condition targeting Apache 2.3.16 is whether to explicitly exclude SSLv2 or not (as it is disabled by default from that point on), not worth maintaining as separate blocks with different formatting etc.

Any SSLv3 logic is removed as it is no longer present in any configs and is also only disabled completely.

## Significant changes and points to review

Absolutely no impact to the actual output.

The `2.3.16` condition for explicit SSLv2 removal is just kept within the single block, SSLv3 removal is unconditional.

(Includes some indentation and whitespace control for better readability, but not as "neat" as before; however the deduplication is hopefully worth it.)

## Testing

https://upd-apache-protocols--mozsslconf-dev.netlify.app/#server=apache&version=2.2.22
https://upd-apache-protocols--mozsslconf-dev.netlify.app/#server=apache&version=2.2.22&config=old
vs.
https://upd-apache-protocols--mozsslconf-dev.netlify.app/#server=apache&version=2.4.24
https://upd-apache-protocols--mozsslconf-dev.netlify.app/#server=apache&version=2.4.24&config=old
https://upd-apache-protocols--mozsslconf-dev.netlify.app/#server=apache&config=modern