### PR TITLE
Disable OpenSSL for Oracle HTTP

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -122,6 +122,7 @@ module.exports = {
     tls13: '1.1.1',
   },
   oraclehttp: {
+    cipherFormat: 'iana',
     highlighter: 'apache',
     latestVersion: '12.2.1',
     name: 'Oracle HTTP',

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -126,8 +126,9 @@ module.exports = {
     latestVersion: '12.2.1',
     name: 'Oracle HTTP',
     supportsHsts: true,
-    supportsOcspStapling: false,  // TODO: fix this, but Oracle's documentation is terrible
+    supportsOcspStapling: false,
     tls13: noSupportedVersion,
+    usesOpenssl: false,
   },
   postfix: {
     highlighter: 'nginx',


### PR DESCRIPTION
OHS uses `mod_ossl` and not `mod_ssl`.

## Rationale

https://docs.oracle.com/en/middleware/fusion-middleware/web-tier/12.2.1.4/administer-ohs/under_mods.html

> **mod_ossl Module**—Enables Cryptography (SSL)
> The mod_ossl module enables strong cryptography for Oracle HTTP Server. It is a plug-in to Oracle HTTP Server that enables the server to use SSL. The functionality of this module is similar to the functionality of Apache’s mod_ssl module. However, the cryptography engine used in the mod_ossl module differs from that of the mod_ssl module. The mod_ossl module uses Oracle’s Secure Socket Layer, which is based on RSA security technology, whereas the mod_ssl module relies on OpenSSL to provide the cryptography engine. […] It uses a version of the underlying SSL libraries that has gone through formal FIPS certification.  […] Oracle no longer supports the mod_ssl module.

## Significant changes and points to review

This disables OpenSSL–specific targeting (as upcoming SECLEVEL etc.) and changes to IANA naming, according to:
- https://docs.oracle.com/middleware/12213/webtier/administer-ohs/GUID-C76BCA2A-9C28-4D16-9758-9346FBCF7512.htm#HSADM1016 (showing colon-separated list as accepted, but using IANA values)