### PR TITLE
Leave out defaults from config options

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -99,7 +99,7 @@ module.exports = {
     highlighter: 'nginx',
     latestVersion: '1.4.67',
     name: 'lighttpd',
-    tls13: '1.4.48'
+    tls13: '1.4.48',
   },
   mysql: {
     highlighter: 'ini',
@@ -126,7 +126,6 @@ module.exports = {
     highlighter: 'apache',
     latestVersion: '12.2.1',
     name: 'Oracle HTTP',
-    supportsHsts: true,
     supportsOcspStapling: false,
     tls13: noSupportedVersion,
     usesOpenssl: false,
@@ -155,7 +154,6 @@ module.exports = {
     name: 'ProFTPD',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: true,
     tls13: '1.3.7',
   },
   redis: {
@@ -166,7 +164,6 @@ module.exports = {
     supportsHsts: false,
     supportsOcspStapling: false,
     tls13: '6.0',
-    usesOpenssl: true,
   },
   squid: {
     highlighter: 'nginx',  // TODO: find better
@@ -181,17 +178,14 @@ module.exports = {
     highlighter: 'ini',
     latestVersion: '5.73',
     name: 'stunnel',
-    showSupports: false,
     supportsHsts: false,
     supportsOcspStapling: false,
     tls13: '5.50',
-    usesOpenssl: true,
   },
   tomcat: {
     highlighter: 'xml',
     latestVersion: '9.0.96',
     name: 'Tomcat',
-    supportsHsts: true,
     supportsOcspStapling: false,
     tls13: '8.0.0',
     usesOpenssl: false,
@@ -201,7 +195,6 @@ module.exports = {
     highlighter: 'ini',
     latestVersion: '2.1.2',
     name: 'Traefik',
-    supportsHsts: true,
     supportsOcspStapling: false,  // https://github.com/containous/traefik/issues/212
     tls13: '2.0.0',
     usesOpenssl: false,


### PR DESCRIPTION
Only list values that are not the default state for given options.

(Also renders supported clients for stunnel, that ought to be shown.)