### PR TITLE
Fix Dovecot v2.3.3+ DH config

### DIFF
--- a/src/templates/partials/dovecot.hbs
+++ b/src/templates/partials/dovecot.hbs
@@ -5,8 +5,8 @@ ssl = required
 ssl_cert = </path/to/signed_cert_plus_intermediates
 ssl_key = </path/to/private_key
 {{#if output.usesDhe}}
-  {{#if (minver "2.3.3" form.serverVersion)}}
-  {{else if (minver "2.3.0" form.serverVersion)}}
+
+  {{#if (minver "2.3.0" form.serverVersion)}}
 # {{output.dhCommand}} > /path/to/dhparam
 ssl_dh = </path/to/dhparam
   {{else}}


### PR DESCRIPTION
Resolves #265

Reverts #175, referencing:

> "Since v2.3.3+ Diffie-Hellman parameters have been made optional, and you are encouraged to disable non-ECC DH algorithms completely."
> — [doc.dovecot.org/configuration_manual/dovecot_ssl_configuration](https://doc.dovecot.org/configuration_manual/dovecot_ssl_configuration/#ssl-security-settings)

The `ssl_dh` config is indeed optional so Dovecot no longer refuses to start without DH params, but we **_do_ need** to configure it for `intermediate` and `old` though.