### PR TITLE
Explicitly exclude SSLv3 in older Oracle HTTP versions

### DIFF
--- a/src/templates/partials/oraclehttp.hbs
+++ b/src/templates/partials/oraclehttp.hbs
@@ -18,7 +18,7 @@
 </VirtualHost>
 
 # {{form.config}} configuration
-SSLProtocol             All {{#unless (includes "TLSv1" output.protocols)}}-TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
+SSLProtocol             All{{#unless (minver "12.2.1" form.serverVersion)}} -SSLv3{{/unless}}{{#unless (includes "TLSv1" output.protocols)}} -TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
 {{#if (minver "12.2.1" form.serverVersion)}}
 SSLHonorCipherOrder     {{#if output.serverPreferredOrder}}on{{else}}off{{/if}}


### PR DESCRIPTION
Only the current branch disables SSLv3 by default (by not supporting it at all), however for older versions it has to be explicitly excluded as it was available, being enabled by default depending on the package it was part of.

Ref: https://docs.oracle.com/middleware/12213/webtier/administer-ohs/GUID-20EE80B2-E97F-4BB8-B980-5069CA3801F9.htm#HSADM1025:
(12.1.2 mentions disabling:) https://docs.oracle.com/middleware/1212/webtier/HSADM/directives.htm#CIHCABAI
(11.1.0 claims it disabled:)
https://docs.oracle.com/middleware/11119/webtier/administer-ohs/directives.htm#CIHCABAI

This adds the extra rule for good measure:

https://add-ohs-sslv3-version--mozsslconf-dev.netlify.app/#server=oraclehttp&version=12.3.4
vs.
https://add-ohs-sslv3-version--mozsslconf-dev.netlify.app/#server=oraclehttp&version=11.1.0