### PR TITLE
Version-based supportsOcspStapling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Highlighted items from src/js/state.js for use in templates.  See src/js/state.j
 - `output.hasVersions` - server config has versions (boolean true/false)
 - `output.supportsConfigs` - supports modern, intermediate, old configs (boolean true/false)
 - `output.supportsHsts` - supports HTTP Strict Transport Security (HSTS) (boolean true/false)
-- `output.supportsOcspStapling` - supports OCSP Stapling (boolean true/false)
+- `output.supportsOcspStapling` - server version supporting OCSP Stapling in config
 - `output.tls13` - minimum server version supporting TLSv1.3
 
 ## Building

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -9,6 +9,7 @@ module.exports = {
     latestVersion: '2.4.60',
     eolBefore: '2.4.0',
     name: 'Apache',
+    supportsOcspStapling: '2.4.13',
     tls13: '2.4.36',
   },
   awsalb: {
@@ -105,6 +106,7 @@ module.exports = {
     latestVersion: '1.4.76',
     eolBefore: '1.4.69',
     name: 'lighttpd',
+    supportsOcspStapling: '1.4.56',
     tls13: '1.4.48',
   },
   mysql: {
@@ -123,6 +125,7 @@ module.exports = {
     latestVersion: '1.27.3',
     eolBefore: '1.26.0',
     name: 'nginx',
+    supportsOcspStapling: '1.3.7',
     tls13: '1.13.0',
   },
   openssl: {
@@ -165,6 +168,7 @@ module.exports = {
     name: 'ProFTPD',
     showSupports: false,
     supportsHsts: false,
+    supportsOcspStapling: '1.3.6',
     tls13: '1.3.7',
   },
   redis: {

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -1,5 +1,5 @@
 // configs for the supported pieces of software
-// hasVersions, showSupports, supportsConfigs, supportsHsts, supportsOcspStapling, and usesOpenssl only need to be defined if false
+// hasVersions, showSupports, supportsConfigs, supportsHsts, and usesOpenssl only need to be defined if false
 // cipherFormat is assumed to be 'openssl' unless defined otherwise
 
 
@@ -31,7 +31,6 @@ module.exports = {
     name: 'AWS ELB',
     supportedCiphers: ['ECDHE-ECDSA-AES128-GCM-SHA256', 'ECDHE-RSA-AES128-GCM-SHA256', 'ECDHE-ECDSA-AES128-SHA256', 'ECDHE-RSA-AES128-SHA256', 'ECDHE-ECDSA-AES128-SHA', 'ECDHE-RSA-AES128-SHA', 'DHE-RSA-AES128-SHA', 'ECDHE-ECDSA-AES256-GCM-SHA384', 'ECDHE-RSA-AES256-GCM-SHA384', 'ECDHE-ECDSA-AES256-SHA384', 'ECDHE-RSA-AES256-SHA384', 'ECDHE-RSA-AES256-SHA', 'ECDHE-ECDSA-AES256-SHA', 'AES128-GCM-SHA256', 'AES128-SHA256', 'AES128-SHA', 'AES256-GCM-SHA384', 'AES256-SHA256', 'AES256-SHA', 'DHE-DSS-AES128-SHA', 'CAMELLIA128-SHA', 'EDH-RSA-DES-CBC3-SHA', 'DES-CBC3-SHA', 'ECDHE-RSA-RC4-SHA', 'RC4-SHA', 'ECDHE-ECDSA-RC4-SHA', 'DHE-DSS-AES256-GCM-SHA384', 'DHE-RSA-AES256-GCM-SHA384', 'DHE-RSA-AES256-SHA256', 'DHE-DSS-AES256-SHA256', 'DHE-RSA-AES256-SHA', 'DHE-DSS-AES256-SHA', 'DHE-RSA-CAMELLIA256-SHA', 'DHE-DSS-CAMELLIA256-SHA', 'CAMELLIA256-SHA', 'EDH-DSS-DES-CBC3-SHA', 'DHE-DSS-AES128-GCM-SHA256', 'DHE-RSA-AES128-GCM-SHA256', 'DHE-RSA-AES128-SHA256', 'DHE-DSS-AES128-SHA256', 'DHE-RSA-CAMELLIA128-SHA', 'DHE-DSS-CAMELLIA128-SHA', 'ADH-AES128-GCM-SHA256', 'ADH-AES128-SHA', 'ADH-AES128-SHA256', 'ADH-AES256-GCM-SHA384', 'ADH-AES256-SHA', 'ADH-AES256-SHA256', 'ADH-CAMELLIA128-SHA', 'ADH-CAMELLIA256-SHA', 'ADH-DES-CBC3-SHA', 'ADH-DES-CBC-SHA', 'ADH-RC4-MD5', 'ADH-SEED-SHA', 'DES-CBC-SHA', 'DHE-DSS-SEED-SHA', 'DHE-RSA-SEED-SHA', 'EDH-DSS-DES-CBC-SHA', 'EDH-RSA-DES-CBC-SHA', 'IDEA-CBC-SHA', 'RC4-MD5', 'SEED-SHA', 'DES-CBC3-MD5', 'DES-CBC-MD5', 'RC2-CBC-MD5', 'PSK-AES256-CBC-SHA', 'PSK-3DES-EDE-CBC-SHA', 'KRB5-DES-CBC3-SHA', 'KRB5-DES-CBC3-MD5', 'PSK-AES128-CBC-SHA', 'PSK-RC4-SHA', 'KRB5-RC4-SHA', 'KRB5-RC4-MD5', 'KRB5-DES-CBC-SHA', 'KRB5-DES-CBC-MD5', 'EXP-EDH-RSA-DES-CBC-SHA', 'EXP-EDH-DSS-DES-CBC-SHA', 'EXP-ADH-DES-CBC-SHA', 'EXP-DES-CBC-SHA', 'EXP-RC2-CBC-MD5', 'EXP-KRB5-RC2-CBC-SHA', 'EXP-KRB5-DES-CBC-SHA', 'EXP-KRB5-RC2-CBC-MD5', 'EXP-KRB5-DES-CBC-MD5', 'EXP-ADH-RC4-MD5', 'EXP-RC4-MD5', 'EXP-KRB5-RC4-SHA', 'EXP-KRB5-RC4-MD5'],
     supportsHsts: false,
-    supportsOcspStapling: false,
     usesOpenssl: false,
   },
   caddy: {
@@ -40,7 +39,6 @@ module.exports = {
     latestVersion: '2.8.4',
     eolBefore: '2.0.0',
     name: 'Caddy',
-    supportsOcspStapling: false, // actually true; can't be disabled in Caddy
     tls13: '0.11.5',
     usesOpenssl: false,
   },
@@ -50,7 +48,6 @@ module.exports = {
     name: 'Coturn',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '4.6.2',
   },
   dovecot: {
@@ -60,7 +57,6 @@ module.exports = {
     name: 'Dovecot',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '2.3.15',
   },
   exim: {
@@ -70,7 +66,6 @@ module.exports = {
     name: 'Exim',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '4.92.0',
   },
   go: {
@@ -79,7 +74,6 @@ module.exports = {
     latestVersion: '1.23.3',
     eolBefore: '1.22.0',
     name: 'Go',
-    supportsOcspStapling: false,
     tls13: '1.13.0',
     usesOpenssl: false,
   },
@@ -97,7 +91,6 @@ module.exports = {
     eolBefore: '12.0.0',
     name: 'Jetty',
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '9.4.12',
     usesOpenssl: false,
   },
@@ -116,7 +109,6 @@ module.exports = {
     name: 'MySQL',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '8.0.16',
   },
   nginx: {
@@ -138,7 +130,6 @@ module.exports = {
     highlighter: 'apache',
     latestVersion: '12.2.1',
     name: 'Oracle HTTP',
-    supportsOcspStapling: false,
     usesOpenssl: false,
   },
   postfix: {
@@ -148,7 +139,6 @@ module.exports = {
     name: 'Postfix',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '3.3.2',
   },
   postgresql: {
@@ -158,7 +148,6 @@ module.exports = {
     name: 'PostgreSQL',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '12.0',
   },
   proftpd: {
@@ -178,7 +167,6 @@ module.exports = {
     name: 'Redis',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '6.0',
   },
   squid: {
@@ -188,7 +176,6 @@ module.exports = {
     name: 'Squid',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '4',
   },
   stunnel: {
@@ -196,7 +183,6 @@ module.exports = {
     latestVersion: '5.73',
     name: 'stunnel',
     supportsHsts: false,
-    supportsOcspStapling: false,
     tls13: '5.50',
   },
   tomcat: {
@@ -204,7 +190,6 @@ module.exports = {
     latestVersion: '11.0.1',
     eolBefore: '9.0.0',
     name: 'Tomcat',
-    supportsOcspStapling: false,
     tls13: '8.0.0',
     usesOpenssl: false,
   },
@@ -214,7 +199,6 @@ module.exports = {
     latestVersion: '3.2.1',
     eolBefore: '2.11.0',
     name: 'Traefik',
-    supportsOcspStapling: false,  // https://github.com/containous/traefik/issues/212
     tls13: '2.0.0',
     usesOpenssl: false,
   },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -47,7 +47,7 @@ const render = async () => {
   $('#version').toggleClass('text-disabled', _state.output.hasVersions === false);
   $('#openssl').toggleClass('text-disabled', _state.output.usesOpenssl === false);
   $('#hsts').prop('disabled', _state.output.supportsHsts === false);
-  $('#ocsp').prop('disabled', _state.output.supportsOcspStapling === false);
+  $('#ocsp').prop('disabled', !_state.output.supportsOcspStapling);
 
   // update the fragment
   if (gHaveSettingsChanged) {

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -9,10 +9,8 @@ export default async function () {
   const server = form['server'].value;
   const ssc = sstls.configurations[form['config'].value];  // server side tls config for that level
   const supportsOcspStapling =
-    typeof configs[server].supportsOcspStapling === 'undefined'
-        || configs[server].supportsOcspStapling === true
-        || (configs[server].supportsOcspStapling !== false
-            && minver(configs[server].supportsOcspStapling, form['version'].value));
+    configs[server].supportsOcspStapling
+    && minver(configs[server].supportsOcspStapling, form['version'].value);
   
   const url = new URL(document.location);
 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -8,6 +8,11 @@ export default async function () {
   const config = form['config'].value;
   const server = form['server'].value;
   const ssc = sstls.configurations[form['config'].value];  // server side tls config for that level
+  const supportsOcspStapling =
+    typeof configs[server].supportsOcspStapling === 'undefined'
+        || configs[server].supportsOcspStapling === true
+        || (configs[server].supportsOcspStapling !== false
+            && minver(configs[server].supportsOcspStapling, form['version'].value));
   
   const url = new URL(document.location);
 
@@ -16,7 +21,7 @@ export default async function () {
   fragment += configs[server].supportsConfigs !== false ? `&config=${config}` : '';
   fragment += configs[server].usesOpenssl !== false ? `&openssl=${form['openssl'].value}` : '';
   fragment += configs[server].supportsHsts !== false && !form['hsts'].checked ? `&hsts=false` : '';
-  fragment += configs[server].supportsOcspStapling !== false && !form['ocsp'].checked ? `&ocsp=false` : '';
+  fragment += supportsOcspStapling && !form['ocsp'].checked ? `&ocsp=false` : '';
   fragment += `&guideline=${sstls.version}`;
 
   // generate the version tags
@@ -37,7 +42,7 @@ export default async function () {
   const date = new Date().toISOString().substr(0, 10);
   let header = `generated ${date}, Mozilla Guideline v${sstls.version}, ${version_tags}`;
   header += configs[server].supportsHsts !== false && !form['hsts'].checked ? `, no HSTS` : '';
-  header += configs[server].supportsOcspStapling !== false && !form['ocsp'].checked ? `, no OCSP` : '';
+  header += supportsOcspStapling && !form['ocsp'].checked ? `, no OCSP` : '';
 
   const link = `${url.origin}${url.pathname}#${fragment}`;
 
@@ -65,7 +70,7 @@ export default async function () {
     form: {
       config: form['config'].value,
       hsts: form['hsts'].checked && configs[server].supportsHsts !== false,
-      ocsp: form['ocsp'].checked && configs[server].supportsOcspStapling !== false,
+      ocsp: form['ocsp'].checked && supportsOcspStapling,
       opensslVersion: form['openssl'].value,
       server,
       serverName: document.querySelector(`label[for=server-${server}]`).innerText,
@@ -93,7 +98,7 @@ export default async function () {
       showSupports: configs[server].showSupports !== false,
       supportsConfigs: configs[server].supportsConfigs !== false,
       supportsHsts: configs[server].supportsHsts !== false,
-      supportsOcspStapling: configs[server].supportsOcspStapling !== false,
+      supportsOcspStapling: supportsOcspStapling,
       usesDhe: ciphers.join(":").includes(":DHE") || ciphers.join(":").includes("_DHE_"), 
       usesOpenssl: configs[server].usesOpenssl !== false,
     },

--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -55,9 +55,7 @@ SSLSessionTickets       off
   {{/if}}
 {{/if}}
 {{#if form.ocsp}}
-  {{#if (minver "2.4.13" form.serverVersion)}}
 
 SSLUseStapling On
 SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"
-  {{/if}}
 {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -55,7 +55,6 @@ server {
     add_header Strict-Transport-Security "max-age={{output.hstsMaxAge}}"{{#if (minver "1.7.5" form.serverVersion)}} always{{/if}};
 {{/if}}
 {{#if form.ocsp}}
-  {{#if (minver "1.3.7" form.serverVersion)}}
 
     # OCSP stapling
     ssl_stapling on;
@@ -66,6 +65,5 @@ server {
 
     # replace with the IP address of your resolver
     resolver 127.0.0.1;
-  {{/if}}
 {{/if}}
 }

--- a/src/templates/partials/proftpd.hbs
+++ b/src/templates/partials/proftpd.hbs
@@ -32,10 +32,8 @@ TLSSessionTickets             off
   {{/if}}
 {{/if}}
 {{#if form.ocsp}}
-  {{#if (minver "1.3.6" form.serverVersion)}}
 
 TLSStapling                   on
 # requires mod_tls_shmcache
 TLSStaplingCache              shm:/file=/var/ftpd/ocsp_pcache
-  {{/if}}
 {{/if}}


### PR DESCRIPTION
Version-based supportsOcspStapling

x-ref:
  "Change supportsOcspStapling from boolean to version based"
  https://github.com/mozilla/ssl-config-generator/issues/138

github: closes #138