### PR TITLE
apache: avoid double-percent-encode in rewrite

### DIFF
--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -6,7 +6,7 @@
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{REQUEST_URI} !^/\.well\-known/acme\-challenge/
-    RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+    RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,QSA,L]
 </VirtualHost>
 
 {{/if}}


### PR DESCRIPTION
apache: avoid double-percent-encode in rewrite

x-ref:
  "Apache rewrite config - double-encoding query strings"
  https://github.com/mozilla/ssl-config-generator/issues/150

github: closes #150