### PR TITLE
nginx: wrap server in http context

### DIFF
--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -1,33 +1,32 @@
 # {{output.header}}
 # {{{output.link}}}
-{{#if form.hsts}}
-server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
 
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
+http {
 
-{{/if}}
-server {
+    server {
 {{#if (minver "1.25.1" form.serverVersion)}}
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
 {{else}}
     {{#if (minver "1.9.5" form.serverVersion)}}
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
     {{else}}
-    listen 443 ssl;
-    listen [::]:443 ssl;
+        listen 443 ssl;
+        listen [::]:443 ssl;
     {{/if}}
 {{/if}}
 
-    ssl_certificate /path/to/signed_cert_plus_intermediates;
-    ssl_certificate_key /path/to/private_key;
+        ssl_certificate /path/to/signed_cert_plus_intermediates;
+        ssl_certificate_key /path/to/private_key;
+{{#if form.hsts}}
+
+        # HSTS (ngx_http_headers_module is required) ({{output.hstsMaxAge}} seconds)
+        add_header Strict-Transport-Security "max-age={{output.hstsMaxAge}}"{{#if (minver "1.7.5" form.serverVersion)}} always{{/if}};
+{{/if}}
+    }
+
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
 {{#unless (minver "1.23.2" form.serverVersion)}}
@@ -49,11 +48,6 @@ server {
     ssl_ciphers {{{join output.ciphers ":"}}};
 {{/if}}
     ssl_prefer_server_ciphers {{#if output.serverPreferredOrder}}on{{else}}off{{/if}};
-{{#if form.hsts}}
-
-    # HSTS (ngx_http_headers_module is required) ({{output.hstsMaxAge}} seconds)
-    add_header Strict-Transport-Security "max-age={{output.hstsMaxAge}}"{{#if (minver "1.7.5" form.serverVersion)}} always{{/if}};
-{{/if}}
 {{#if form.ocsp}}
 
     # OCSP stapling
@@ -66,4 +60,15 @@ server {
     # replace with the IP address of your resolver
     resolver 127.0.0.1;
 {{/if}}
+{{#if form.hsts}}
+
+    # HSTS
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+
+        return 301 https://$host$request_uri;
+    }
+{{/if}}
+
 }


### PR DESCRIPTION
nginx: wrap server in http context

share most of the ssl config in the http context