### PR TITLE
config TLSv1.3 key exchange groups where supported

### DIFF
--- a/src/js/state.js
+++ b/src/js/state.js
@@ -97,6 +97,7 @@ export default async function () {
       supportsConfigs: configs[server].supportsConfigs !== false,
       supportsHsts: configs[server].supportsHsts !== false,
       supportsOcspStapling: supportsOcspStapling,
+      tlsCurves: ssc.tls_curves,
       usesDhe: ciphers.join(":").includes(":DHE") || ciphers.join(":").includes("_DHE_"), 
       usesOpenssl: configs[server].usesOpenssl !== false,
     },

--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -39,6 +39,9 @@
 
 # {{form.config}} configuration
 SSLProtocol             {{{join output.protocols " "}}}
+{{#if (minver "2.4.8" form.serverVersion)}}
+SSLOpenSSLConfCmd       Curves {{{join output.tlsCurves ":"}}}
+{{/if}}
 {{#if output.ciphers.length}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -14,9 +14,10 @@ example.com {
 
   {{/if}}
     # Note: Caddy automatically configures safe TLS settings,
-    # so 'ciphers' may safely be commented out to use Caddy defaults.
+    # so 'ciphers' and 'curves' may safely be commented out to use Caddy defaults.
     ciphers {{{join output.ciphers " "}}}
 {{/if}}
+    curves x25519 secp256r1 secp384r1
 {{#if (includes "TLSv1.2" output.protocols)}}
   {{#if (includes "TLSv1.1" output.protocols)}}
     # Note: Caddy supports only TLSv1.2 and later

--- a/src/templates/partials/dovecot.hbs
+++ b/src/templates/partials/dovecot.hbs
@@ -20,6 +20,7 @@ ssl_min_protocol = {{output.protocols.[0]}}
 {{else}}
 ssl_protocols = {{join output.protocols " "}}
 {{/if}}
+ssl_curve_list = {{{join output.tlsCurves ":"}}}
 {{#if output.ciphers.length}}
 ssl_cipher_list = {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/exim.hbs
+++ b/src/templates/partials/exim.hbs
@@ -11,6 +11,11 @@ tls_dhparam = /path/to/dhparam
 
 # {{form.config}} configuration
 openssl_options = +no_sslv2 +no_sslv3{{#unless (includes "TLSv1" output.protocols)}} +no_tlsv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} +no_tlsv1_1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}} +no_tlsv1_2{{/unless}}
+{{#if (minver "4.97" form.serverVersion)}}
+{{#if (minver "1.1.1" form.opensslVersion)}}
+tls_eccurve = "{{{join output.tlsCurves ':'}}}"
+{{/if}}
+{{/if}}
 {{#if output.ciphers.length}}
 tls_require_ciphers = {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/go.hbs
+++ b/src/templates/partials/go.hbs
@@ -42,6 +42,12 @@ func main() {
 {{/if}}
     cfg := &tls.Config{
         MinVersion: tls.{{#if (eq output.protocols.[0] "TLSv1")}}VersionTLS10{{else}}{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}{{/if}},
+        CurvePreferences: []tls.CurveID{
+            tls.X25519, // Go 1.8+
+            tls.CurveP256,
+            tls.CurveP384,
+            //tls.x25519Kyber768Draft00, // Go 1.23+
+        },
 {{#if output.serverPreferredOrder}}
         PreferServerCipherSuites: true,
 {{/if}}

--- a/src/templates/partials/haproxy.hbs
+++ b/src/templates/partials/haproxy.hbs
@@ -4,6 +4,7 @@
 {{#if (minver "1.5.0" form.serverVersion)}}
 global
     # {{form.config}} configuration
+    ssl-default-bind-curves {{{join output.tlsCurves ":"}}}
 {{#if output.ciphers.length}}
     ssl-default-bind-ciphers {{{join output.ciphers ":"}}}
 {{/if}}
@@ -14,6 +15,7 @@ global
 {{/if}}
     ssl-default-bind-options{{#if (minver "1.8.0" form.serverVersion)}}{{#unless output.serverPreferredOrder}} prefer-client-ciphers{{/unless}}{{/if}}{{#if (minver "2.2.0" form.serverVersion)}} ssl-min-ver {{#if (includes "TLSv1" output.protocols)}}TLSv1.0{{else}}{{output.protocols.[0]}}{{/if}}{{else}}{{#unless (includes "SSLv3" output.protocols)}} no-sslv3{{/unless}}{{#unless (includes "TLSv1" output.protocols)}} no-tlsv10{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} no-tlsv11{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}} no-tlsv12{{/unless}}{{/if}} no-tls-tickets
 
+    ssl-default-server-curves {{{join output.tlsCurves ":"}}}
 {{#if output.ciphers.length}}
     ssl-default-server-ciphers {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/lighttpd.hbs
+++ b/src/templates/partials/lighttpd.hbs
@@ -40,6 +40,7 @@ ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.3")
   {{else}}
 ssl.openssl.ssl-conf-cmd = ("Protocol" => "-ALL, {{{join output.protocols ", "}}}")
   {{/if}}
+ssl.openssl.ssl-conf-cmd += ("Curves" => "{{{join output.tlsCurves ':'}}}")
   {{#if (minver "1.4.68" form.serverVersion)}}
    {{#if output.serverPreferredOrder}}
 ssl.openssl.ssl-conf-cmd += ("Options" => "+ServerPreference")
@@ -106,8 +107,10 @@ $SERVER["socket"] == ":443" {
  {{#if (minver "1.4.48" form.serverVersion)}}
   {{#if (minver "1.1.0" form.opensslVersion)}}
     ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "{{output.protocols.[0]}}", "Options" => "-SessionTicket")
+    ssl.openssl.ssl-conf-cmd += ("Curves" => "{{{join output.tlsCurves ':'}}}")
   {{else if (minver "1.0.2" form.opensslVersion)}}
     ssl.openssl.ssl-conf-cmd = ("Protocol" => "-ALL, {{{join output.protocols ", "}}}", "Options" => "-SessionTicket")
+    ssl.openssl.ssl-conf-cmd += ("Curves" => "{{{join output.tlsCurves ':'}}}")
   {{else}}
     ssl.use-sslv2 = "disable"
     ssl.use-sslv3 = "disable"

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -44,6 +44,7 @@ http {
 {{/if}}
     # {{form.config}} configuration
     ssl_protocols {{join output.protocols " "}};
+    ssl_ecdh_curve {{join output.tlsCurves ":"}};
 {{#if output.ciphers.length}}
     ssl_ciphers {{{join output.ciphers ":"}}};
 {{/if}}

--- a/src/templates/partials/postfix.hbs
+++ b/src/templates/partials/postfix.hbs
@@ -27,6 +27,8 @@ smtp_tls_mandatory_protocols = !SSLv2, !SSLv3{{#unless (includes "TLSv1" output.
 smtp_tls_protocols = !SSLv2, !SSLv3{{#unless (includes "TLSv1" output.protocols)}}, !TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}}, !TLSv1.1{{/unless}}{{#unless (includes "TLSv1.2" output.protocols)}}, !TLSv1.2{{/unless}}
 {{/if}}
 
+tls_eecdh_auto_curves = {{{join output.tlsCurves " "}}}
+tls_ffdhe_auto_groups =
 {{#if output.ciphers.length}}
 smtp_tls_mandatory_ciphers = medium
 smtpd_tls_mandatory_ciphers = medium

--- a/src/templates/partials/postgresql.hbs
+++ b/src/templates/partials/postgresql.hbs
@@ -15,6 +15,9 @@ ssl_dh_params_file = '/path/to/dhparam'
 
 ssl_ciphers = '{{{join output.ciphers ":"}}}'
 {{/if}}
+{{#if (minver "18.0.0" form.serverVersion)}}
+ssl_groups = '{{{join output.tlsCurves ":"}}}'
+{{/if}}
 {{#if (minver "12.0.0" form.serverVersion)}}
 ssl_min_protocol_version = '{{output.protocols.[0]}}'
 {{/if}}

--- a/src/templates/partials/proftpd.hbs
+++ b/src/templates/partials/proftpd.hbs
@@ -20,6 +20,9 @@ TLSDHParamFile                /path/to/dhparam
 
 # {{form.config}} configuration
 TLSProtocol                   {{join output.protocols " "}}
+{{#if (minver "1.0.2" form.opensslVersion)}}
+TLSECDHCurve                  {{{join output.tlsCurves ":"}}}
+{{/if}}
 {{#if output.ciphers.length}}
 TLSCipherSuite                {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/stunnel.hbs
+++ b/src/templates/partials/stunnel.hbs
@@ -24,6 +24,9 @@ options = NO_TLSv1
 options = NO_SSLv3
 options = NO_SSLv2
 {{/unless}}
+{{#if (minver "1.1.1" form.opensslVersion)}}
+curves = {{{join output.tlsCurves ":"}}}
+{{/if}}
 {{#if output.ciphers.length}}
 ciphers = {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/traefik.hbs
+++ b/src/templates/partials/traefik.hbs
@@ -36,6 +36,7 @@
 [tls.options]
   [tls.options.{{form.config}}]
     minVersion = "{{{replace output.protocols.[0] "TLSv1." "VersionTLS1"}}}"
+    curvePreferences = ["X25519", "CurveP256", "CurveP384"]
     {{#if output.ciphers.length}}
     cipherSuites = [
     {{#each output.ciphers}}


### PR DESCRIPTION
config TLSv1.3 key exchange groups where supported

The reason to explicitly configure Groups is due to OpenSSL 3.0 adding ffdhe* groups to the defaults, potentially exposing servers supporting TLSv1.3 and OpenSSL 3.0 to DHEater attacks. (See https://github.com/mozilla/ssl-config-generator/issues/162)

Note: .hbs additions have been made from the documentation and have not been tested on the all the server apps.
Some slight syntax adjustment may turn out to be needed.

Note: This PR exposes the TLS curves that are already defined in the guidelines.  This is not a change to the guidelines.  However, the curves were not previously exposed in ssl-config-generator configs.  This PR implements the Groups/Curves config in server apps that have config support.