### PR TITLE
apache,oraclehttp: explicit SSLProtocol list

### DIFF
--- a/src/templates/partials/apache.hbs
+++ b/src/templates/partials/apache.hbs
@@ -38,10 +38,7 @@
 </VirtualHost>
 
 # {{form.config}} configuration
-SSLProtocol             all {{#unless (minver "2.3.16" form.serverVersion)}}-SSLv2 {{/unless}}-SSLv3
-                        {{~#unless (includes "TLSv1" output.protocols)}} -TLSv1{{/unless}}
-                        {{~#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
-                        {{~#unless (includes "TLSv1.2" output.protocols)}} -TLSv1.2{{/unless}}
+SSLProtocol             {{{join output.protocols " "}}}
 {{#if output.ciphers.length}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/oraclehttp.hbs
+++ b/src/templates/partials/oraclehttp.hbs
@@ -18,7 +18,7 @@
 </VirtualHost>
 
 # {{form.config}} configuration
-SSLProtocol             All {{#unless (includes "TLSv1" output.protocols)}}-TLSv1{{/unless}}{{#unless (includes "TLSv1.1" output.protocols)}} -TLSv1.1{{/unless}}
+SSLProtocol             {{{join output.protocols " "}}}
 SSLCipherSuite          {{{join output.ciphers ":"}}}
 {{#if (minver "12.2.1" form.serverVersion)}}
 SSLHonorCipherOrder     {{#if output.serverPreferredOrder}}on{{else}}off{{/if}}


### PR DESCRIPTION
use an explicit list of allowed protocols to avoid having to special-case 'All -SSLv2 -SSLv3' or 'All -SSLv3' depending on version support

x-ref:
  Explicitly exclude SSLv3 in older Oracle HTTP versions
  https://github.com/mozilla/ssl-config-generator/pull/271

github: closes #271