### PR TITLE
use plain javascript to replace jquery

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 // bootstrap.native used only by 'copy' button tooltip
 import * as BSN from "bootstrap.native";
 import ClipboardJS from 'clipboard';
@@ -55,13 +53,14 @@ const render = async () => {
   const _state = await state();
 
   // enable and disable the appropriate fields
-  $('#version').toggleClass('text-disabled', _state.output.hasVersions === false);
-  $('#openssl').toggleClass('text-disabled', _state.output.usesOpenssl === false);
-  $('#hsts').prop('disabled', _state.output.supportsHsts === false);
-  $('#ocsp').prop('disabled', !_state.output.supportsOcspStapling);
+  document.getElementById('version').classList.toggle('text-disabled', _state.output.hasVersions === false);
+  document.getElementById('openssl').classList.toggle('text-disabled', _state.output.usesOpenssl === false);
+  document.getElementById('hsts').classList.toggle('d-none', _state.output.supportsHsts === false);
+  document.getElementById('ocsp').classList.toggle('d-none', !_state.output.supportsOcspStapling);
 
   // update the fragment
   if (gHaveSettingsChanged) {
+    gHaveSettingsChanged = false;
     window.location.hash = _state.output.fragment;
   }
   
@@ -93,10 +92,7 @@ const render = async () => {
 };
 
 
-// set a listen on the form to update the state
-$().ready(() => {
-  // set all the buttons to the right thing
-  if (window.location.hash.length > 0) {
+function form_config_init() {
     const mappings = {
       'true': true,
       'false': false,
@@ -114,7 +110,8 @@ $().ready(() => {
 
     // set the default server version, if we're loading and have "server" but not "version"
     if (params.get('server') !== null && params.get('version') === null) {
-      $('#version').val(configs[params.get('server')].latestVersion);
+      const e_version = document.getElementById('version')
+      e_version.value = configs[params.get('server')].latestVersion;
     }
 
     for (let entry of params.entries()) {
@@ -140,23 +137,35 @@ $().ready(() => {
 
       }
     }
+}
+
+
+export function server_change() {
+    const form = document.getElementById('form-generator').elements;
+    const latestVersion = configs[form['server'].value].latestVersion;
+    document.getElementById('version').value = latestVersion;
+    gHaveSettingsChanged = true;
+    render();
+}
+
+
+function init_once() {
+
+  // set all the buttons to the right thing
+  if (window.location.hash.length > 0) {
+    form_config_init();
   }
 
   // update the global state with the default values
   render();
 
-  // update state anytime the form is changed
-  $('#form-config, #form-environment').on('change', async () => {
+  // set listeners on the form to update state any time form is changed
+  document.getElementById('form-config').addEventListener('change', async () => {
     gHaveSettingsChanged = true;
     render();
   });
-
-  // anytime the server changes, so does the server version
-  $('.form-server').on('change', async () => {
+  document.getElementById('form-environment').addEventListener('change', async () => {
     gHaveSettingsChanged = true;
-    const _state = await state();
-    $('#version').val(_state.output.latestVersion);
-
     render();
   });
 
@@ -172,4 +181,14 @@ $().ready(() => {
     await sleep(750);
     copy_tt.hide();
   });
-});
+}
+
+
+if (document.readyState === "loading") {
+  // Loading hasn't finished yet
+  document.addEventListener("DOMContentLoaded", init_once);
+}
+else {
+  // `DOMContentLoaded` has already fired
+  init_once();
+}

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -38,7 +38,7 @@
               if (config[1].name) {
           %>
             <div class="form-check">
-              <input class="form-check-input" type="radio" name="server" id="server-<%= config[0] %>" value="<%= config[0] %>">
+              <input class="form-check-input" type="radio" name="server" onclick="SSLConfigGenerator.server_change()" id="server-<%= config[0] %>" value="<%= config[0] %>">
               <label class="form-check-label" for="server-<%= config[0] %>">
                 <%= config[1].name %>
               </label>


### PR DESCRIPTION
use plain javascript to replace jquery

bugfix: avoid repeated calls to state() for single change

x-ref:
  https://github.com/mozilla/ssl-config-generator/pull/244
  https://github.com/mozilla/ssl-config-generator/pull/283
  https://github.com/mozilla/ssl-config-generator/pull/288