### PR TITLE
Revert "use js to replace jquery"

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 // bootstrap.native used only by 'copy' button tooltip
 import * as BSN from "bootstrap.native";
 import ClipboardJS from 'clipboard';
@@ -53,14 +55,13 @@ const render = async () => {
   const _state = await state();
 
   // enable and disable the appropriate fields
-  document.getElementById('version').classList.toggle('text-disabled', _state.output.hasVersions === false);
-  document.getElementById('openssl').classList.toggle('text-disabled', _state.output.usesOpenssl === false);
-  document.getElementById('hsts').classList.toggle('d-none', _state.output.supportsHsts === false);
-  document.getElementById('ocsp').classList.toggle('d-none', !_state.output.supportsOcspStapling);
+  $('#version').toggleClass('text-disabled', _state.output.hasVersions === false);
+  $('#openssl').toggleClass('text-disabled', _state.output.usesOpenssl === false);
+  $('#hsts').prop('disabled', _state.output.supportsHsts === false);
+  $('#ocsp').prop('disabled', !_state.output.supportsOcspStapling);
 
   // update the fragment
   if (gHaveSettingsChanged) {
-    gHaveSettingsChanged = false;
     window.location.hash = _state.output.fragment;
   }
   
@@ -92,7 +93,10 @@ const render = async () => {
 };
 
 
-function form_config_init() {
+// set a listen on the form to update the state
+$().ready(() => {
+  // set all the buttons to the right thing
+  if (window.location.hash.length > 0) {
     const mappings = {
       'true': true,
       'false': false,
@@ -110,8 +114,7 @@ function form_config_init() {
 
     // set the default server version, if we're loading and have "server" but not "version"
     if (params.get('server') !== null && params.get('version') === null) {
-      const e_version = document.getElementById('version')
-      e_version.value = configs[params.get('server')].latestVersion;
+      $('#version').val(configs[params.get('server')].latestVersion);
     }
 
     for (let entry of params.entries()) {
@@ -137,35 +140,23 @@ function form_config_init() {
 
       }
     }
-}
-
-
-export function server_change() {
-    const form = document.getElementById('form-generator').elements;
-    const latestVersion = configs[form['server'].value].latestVersion;
-    document.getElementById('version').value = latestVersion;
-    gHaveSettingsChanged = true;
-    render();
-}
-
-
-function init_once() {
-
-  // set all the buttons to the right thing
-  if (window.location.hash.length > 0) {
-    form_config_init();
   }
 
   // update the global state with the default values
   render();
 
-  // set listeners on the form to update state any time form is changed
-  document.getElementById('form-config').addEventListener('change', async () => {
+  // update state anytime the form is changed
+  $('#form-config, #form-environment').on('change', async () => {
     gHaveSettingsChanged = true;
     render();
   });
-  document.getElementById('form-environment').addEventListener('change', async () => {
+
+  // anytime the server changes, so does the server version
+  $('.form-server').on('change', async () => {
     gHaveSettingsChanged = true;
+    const _state = await state();
+    $('#version').val(_state.output.latestVersion);
+
     render();
   });
 
@@ -181,14 +172,4 @@ function init_once() {
     await sleep(750);
     copy_tt.hide();
   });
-}
-
-
-if (document.readyState === "loading") {
-  // Loading hasn't finished yet
-  document.addEventListener("DOMContentLoaded", init_once);
-}
-else {
-  // `DOMContentLoaded` has already fired
-  init_once();
-}
+});

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -38,7 +38,7 @@
               if (config[1].name) {
           %>
             <div class="form-check">
-              <input class="form-check-input" type="radio" name="server" onclick="SSLConfigGenerator.server_change()" id="server-<%= config[0] %>" value="<%= config[0] %>">
+              <input class="form-check-input" type="radio" name="server" id="server-<%= config[0] %>" value="<%= config[0] %>">
               <label class="form-check-label" for="server-<%= config[0] %>">
                 <%= config[1].name %>
               </label>


### PR DESCRIPTION
Revert "use js to replace jquery"

This reverts commit 918ebaace30ce48cf7801655f4e3c140405778d0.


I need to review the policy or find a different mechanism to reset the form upon change in server selection

> Content-Security-Policy: The page’s settings blocked an event handler (script-src-attr) from being executed because it violates the following directive: “script-src 'self' https://www.google-analytics.com/analytics.js https://www.googletagmanager.com/gtag/js”
> Source: SSLConfigGenerator.server_change()