### PR TITLE
use plain javascript to replace jquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "clipboard": "^2.0.11",
         "handlebars": "^4.7.8",
         "highlight.js": "^11.10.0",
-        "jquery": "^3.7.1",
         "semver": "^6.3.1"
       },
       "devDependencies": {
@@ -5022,12 +5021,6 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "clipboard": "^2.0.11",
     "handlebars": "^4.7.8",
     "highlight.js": "^11.10.0",
-    "jquery": "^3.7.1",
     "semver": "^6.3.1"
   },
   "devDependencies": {

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -31,7 +31,7 @@
     <form id="form-generator">
       <div class="form-row">
         <!-- server software, populated from entries in configs.js with names -->
-        <div class="col-12 col-md-2 form-server">
+        <div class="col-12 col-md-2" id="form-server-1">
           <h5>Server Software</h5>
           <%
             Object.entries(htmlWebpackPlugin.options.configs).forEach((config, i) => {
@@ -45,7 +45,7 @@
             </div>
             <% if (Math.floor(Object.entries(htmlWebpackPlugin.options.configs).length / 2) === (i + 1)) { %>
         </div>
-        <div class="col-12 col-md-2 form-server">
+        <div class="col-12 col-md-2" id="form-server-2">
         <h5 class="d-none d-md-block">&nbsp;</h5>
             <% } %>
 
@@ -85,7 +85,7 @@
             <div class="input-group-prepend">
               <span class="input-group-text">Server Version</span>
             </div>
-            <input type="text" class="form-control" aria-label="Server Version" aria-described="version" id="version" value="<%= htmlWebpackPlugin.options.configs.nginx.latestVersion %>">
+            <input type="text" class="form-control" aria-label="Server Version" aria-described="version" id="version" value="">
           </div>
           <div class="input-group mt-2">
             <div class="input-group-prepend">


### PR DESCRIPTION
use plain javascript to replace jquery

bugfix: avoid repeated calls to state() for single change

x-ref:
https://github.com/mozilla/ssl-config-generator/pull/244
https://github.com/mozilla/ssl-config-generator/pull/283
https://github.com/mozilla/ssl-config-generator/pull/288
https://github.com/mozilla/ssl-config-generator/pull/289
https://github.com/mozilla/ssl-config-generator/pull/290