### PR TITLE
haproxy: ssl-default-server-curves added in 2.9.0

### DIFF
--- a/src/js/helpers/haproxy.js
+++ b/src/js/helpers/haproxy.js
@@ -8,7 +8,10 @@ export default (form, output) => {
 
  function haproxy_ssl_default_opts (tag) {
    var conf =
-      '    ssl-default-'+tag+'-curves '+output.tlsCurves.join(':')+'\n'+
+      (minver("2.9.0", form.serverVersion) || tag === 'bind'
+        ?
+      '    ssl-default-'+tag+'-curves '+output.tlsCurves.join(':')+'\n'
+        : '')+
       (output.ciphers.length
         ?
       '    ssl-default-'+tag+'-ciphers '+output.ciphers.join(':')+'\n'


### PR DESCRIPTION
haproxy: ssl-default-server-curves added in 2.9.0

x-ref:
  "HAProxy config uses ssl-default-server-curves for versions that do not support it"
  https://github.com/mozilla/ssl-config-generator/issues/311

github: fixes #311