### PR TITLE
Update Google Analytics ID

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -15,7 +15,7 @@ if (doNotTrack !== '1' && doNotTrack !== 'yes') {
   gtag('js', new Date());
   gtag(
     'config',
-    'UA-66267220-1',
+    'G-ZRW9P16BD8',
     {
       'anonymize_ip': true,
     }

--- a/src/static/guidelines/CHANGELOG.md
+++ b/src/static/guidelines/CHANGELOG.md
@@ -22,6 +22,7 @@ This project doesn't adhere to [Semantic Versioning](https://semver.org/spec/v2.
 - nginx: allow ssl\_session\_tickets for nginx ≥1.23.2
 - nginx: wrap `server` in `http` context
 - postfix: add `smtp_tls_*`
+- google analytics: change UA to GA4 ID
 
 ### Added
 

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -6,7 +6,7 @@
       https://bugzilla.mozilla.org/show_bug.cgi?id=1122305#c8
     -->
     <% if (htmlWebpackPlugin.options.production) { %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-66267220-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZRW9P16BD8"></script>
     <script src="/analytics.js"></script>
     <% } %>
 


### PR DESCRIPTION
With the [move to Google Analytics 4][1] this updates the Measurement ID from the old "UA" ID to the new "G" ID. This shouldn't have any impact on the metrics being collected.

Fixes #242

[1]: https://support.google.com/analytics/answer/11583528