### PR TITLE
nginx: fix missing semicolon

### DIFF
--- a/src/js/helpers/nginx.js
+++ b/src/js/helpers/nginx.js
@@ -73,7 +73,7 @@ export default (form, output) => {
     conf +=
       '\n'+
       '    # '+output.dhCommand+' > /path/to/dhparam\n'+
-      '    ssl_dhparam "/path/to/dhparam"\n';
+      '    ssl_dhparam "/path/to/dhparam";\n';
  }
 
  if (form.ocsp) {


### PR DESCRIPTION
nginx: fix missing semicolon

x-ref:
  "Semicolon missing after ssl_dhparam in nginx config"
  https://github.com/mozilla/ssl-config-generator/issues/324

github: closes #324