### PR TITLE
go: fix unescaped newline in generated string literal

### DIFF
--- a/src/js/helpers/go.js
+++ b/src/js/helpers/go.js
@@ -21,7 +21,7 @@ export default (form, output) => {
         ?
       '        w.Header().Add("Strict-Transport-Security", "max-age='+output.hstsMaxAge+'")\n'
         : '')+
-      '        w.Write([]byte("This server is running the Mozilla '+form.config+' configuration.\n"))\n'+
+      '        w.Write([]byte("This server is running the Mozilla '+form.config+' configuration.\\n"))\n'+
       '    })\n';
 
  if (form.hsts) {


### PR DESCRIPTION
fix syntax error in the generated Go code and ensure newline in HTTP reply