### PR TITLE
traefik: add missing double quotes for TOML-sytax

### DIFF
--- a/src/js/helpers/traefik.js
+++ b/src/js/helpers/traefik.js
@@ -2,7 +2,7 @@ import minver from './minver.js';
 
 export default (form, output) => {
  var tlsopts =
-      '      minVersion = '+(output.protocols[0] === 'TLSv1' ? 'VersionTLS10' : output.protocols[0].replace('TLSv1.', 'VersionTLS1'))+'\n'+
+      '      minVersion = "'+(output.protocols[0] === 'TLSv1' ? 'VersionTLS10' : output.protocols[0].replace('TLSv1.', 'VersionTLS1'))+'"\n'+
       '      curvePreferences = ["X25519", "CurveP256", "CurveP384"]\n';
  if (output.ciphers.length) {
     tlsopts +=


### PR DESCRIPTION
This addresses issue #337 "Generated TOML for Traefik contains small syntax error".