### PR TITLE
Add missing brace in AWS ELB template

### DIFF
--- a/src/js/helpers/awselb.js
+++ b/src/js/helpers/awselb.js
@@ -46,7 +46,7 @@ Resources:
       AvailabilityZones:
         Fn::GetAZs: !Ref 'AWS::Region'
       Policies:
-        - PolicyName: Mozilla-$form.config}-v5-0
+        - PolicyName: Mozilla-${form.config}-v5-0
           PolicyType: SSLNegotiationPolicyType
           Attributes:
 ${attributes}


### PR DESCRIPTION
This seems to have been introduced by the conversion from handlebars in ef3923c430e8069f9a15ca53edc6a6f699b81dc1.